### PR TITLE
Fixed error in issue #10

### DIFF
--- a/src/MatDBForge/active_learning/run_ase_active_learning.py
+++ b/src/MatDBForge/active_learning/run_ase_active_learning.py
@@ -3,8 +3,8 @@
 import pathlib as pl
 
 from aiida import load_profile
-from aiida.engine import run, submit
-from aiida.orm import Int, SinglefileData
+from aiida.engine import run
+from aiida.orm import Dict, Int
 from aiida.plugins import WorkflowFactory
 
 if __name__ == "__main__":
@@ -22,33 +22,69 @@ if __name__ == "__main__":
 
     # Getting builder for workchain
     al_calculation = WorkflowFactory("mdb-active-learning-base")
-    builder = al_calculation.get_builder()
+    bldr = al_calculation.get_builder()
 
     # Setting mandatory inputs.
     # Input settings
-    builder.active_learning.data_path = str(init_db_path)  # str(data_path)
-    builder.active_learning.mace_settings_path = str(mace_settings_path)
-    builder.active_learning.init_db_path = str(init_db_path)
-    builder.active_learning.final_db_path = str(final_db_path)
-    # builder.active_learning.mace_potential_names = mace_potential_names
+    bldr.active_learning.data_path = str(init_db_path)  # str(data_path)
+    bldr.active_learning.mace_settings_path = str(mace_settings_path)
+    bldr.active_learning.init_db_path = str(init_db_path)
+    bldr.active_learning.final_db_path = str(final_db_path)
+    # bldr.active_learning.mace_potential_names = mace_potential_names
 
     # TESTING: Update seed once debugging is done
     # MD settings
     # Size of the seed generating database in percentage of the total number of
     # available training structures
-    builder.active_learning.seed_size_frac = 0.02  # TESTING: 0.0010
-    builder.active_learning.md_temperature_K = 300.0
-    builder.active_learning.md_num_steps = 100 # TESTING: 33334
-    builder.active_learning.md_timestep_duration_ps = 0.003
-    builder.active_learning.commitee_num_models = 2  # 4
-    # builder.active_learning.lammps_potential_path = str(potential_path)
+    bldr.active_learning.seed_size_frac = 0.02  # TESTING: 0.0010
+    bldr.active_learning.md_temperature_K = 300.0
+    bldr.active_learning.md_num_steps = 100  # TESTING: 33334
+    bldr.active_learning.md_timestep_duration_ps = 0.003
+    bldr.active_learning.commitee_num_models = 2  # 4
+    # bldr.active_learning.lammps_potential_path = str(potential_path)
+
+    mace_train_dict = {
+        "code": "mace_run_train_gpu@tekla2-new-test",
+        "metadata": {
+            "options": {
+                "resources": {
+                    "parallel_env": "c128m1024ib_mpi_32slotsbis",
+                    "tot_num_mpiprocs": 32,
+                },
+                "parser_name": "mace-training-parser",
+                "queue_name": "c128m1024ibgpu4.q",
+                "max_wallclock_seconds": 117280000,
+                "max_memory_kb": 102400000,
+                "account": "",
+                "qos": "",
+                "custom_scheduler_commands": ("#$ -l gpu=1"),
+            },
+        },
+        "result_force_weight": 0.1
+    }
+    # bldr.active_learning.mace_train.code = "mace_run_train_gpu@tekla2-new-test"
+    # bldr.active_learning.mace_train.metadata.options.resources = {
+    #     "parallel_env": "c128m1024ib_mpi_32slotsbis",
+    #     "tot_num_mpiprocs": 32,
+    # }
+    # bldr.active_learning.mace_train.metadata.options.parser_name = "mace-training-parser"
+    # bldr.active_learning.mace_train.metadata.options.queue_name = "c128m1024ibgpu4.q"
+    # bldr.active_learning.mace_train.metadata.options.max_wallclock_seconds = 117280000
+    # bldr.active_learning.mace_train.metadata.options.max_memory_kb = 102400000
+    # bldr.active_learning.mace_train.metadata.options.account = ""
+    # bldr.active_learning.mace_train.metadata.options.qos = ""
+    # bldr.active_learning.mace_train.metadata.options.custom_scheduler_commands = (
+    #     "#$ -l gpu=1"
+    # )
+    # bldr.active_learning.mace_train.force_weight_results = "mace_run_train_gpu@tekla2-new-test"
+    bldr.active_learning.mace_train = Dict(value=mace_train_dict)
 
     # AL settings
-    builder.max_iterations = Int(10)
+    bldr.max_iterations = Int(10)
     # Frames to keep for DFT
     # TODO: Test these values
-    builder.active_learning.al_keep_frame_interval_perc = 0.005  # TESTING: 0.01 # 0.005
+    bldr.active_learning.al_keep_frame_interval_perc = 0.005  # TESTING: 0.01 # 0.005
 
     # TESTING: This should use aiida.engine.submit function once all debugging is done.
-    node = run(builder)
+    node = run(bldr)
     # print("node: ", node.pk)

--- a/src/MatDBForge/workflows/active_learning.py
+++ b/src/MatDBForge/workflows/active_learning.py
@@ -253,6 +253,7 @@ class ActiveLearningWorkChain(WorkChain):
             valid_type=Str,
             serializer=to_aiida_type,
         )
+        spec.input("mace_train", valid_type=Dict)
 
         spec.outline(
             # Training the main mace model (M0) and the commitee models
@@ -376,7 +377,7 @@ class ActiveLearningWorkChain(WorkChain):
             future = self.submit(mace_builder)
             self.to_context(mace_training_results=append_(future))
 
-    def get_mace_train_output(self, force_weight: float = 0.1):
+    def get_mace_train_output(self):
         """
         Retrieve and process MACE training output for model selection.
 
@@ -386,12 +387,6 @@ class ActiveLearningWorkChain(WorkChain):
         the importance of forces via a weighting factor, and processes the best model
         to create a LAMMPS-compatible potential file. Information about the selected
         model and committee models is updated in the context for further use.
-
-        Parameters
-        ----------
-        force_weight : float, optional
-            The weighting factor for the force RMSE in the E+F calculation. Defaults
-            to 0.1.
 
         Returns
         -------
@@ -415,6 +410,7 @@ class ActiveLearningWorkChain(WorkChain):
 
             # Adding E + F multiplied by a weight value, in order to consider
             # forces when deciding which model to keep
+            force_weight = self.inputs.mace_train.get("result_force_weight", 0.1)
             weighted_E_F_sum = curr_calc.outputs.m_rmse_e.value + (
                 force_weight * curr_calc.outputs.m_rmse_f
             )
@@ -1125,6 +1121,11 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
         """Define the process specification."""
         super().define(spec)
 
+        ##########
+        # FIXME  #
+        ##########
+        # TODO: There are some problems when exposing the inputs and outputs
+        ##########
         spec.expose_inputs(
             ActiveLearningWorkChain,
             namespace="active_learning",
@@ -1137,6 +1138,7 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
                 "database_training",
             ],
         )
+
         spec.expose_outputs(
             ActiveLearningWorkChain,
             exclude=[
@@ -1144,6 +1146,7 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
                 "final_model_file",
             ],
         )
+
         spec.outline(
             # Load the initial database (D_ini), that will be used as the
             # training database (Dt) without changing the original database.


### PR DESCRIPTION
The error was caused by the addition of an argument to the get_mace_train_output function, which resulted in failure to parse it during the workchain creation.

This commit fixes this by removing the argument, and adding it instead as an input of the runscript. However, this results in input changes that will be implemented with the next commit.