### PR TITLE
Extrapolation basic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="MatDBForge",
-    version="0.2.5",
+    version="0.2.7",
     description="MatDBForge",
     author="Pol Sanz",
     author_email="me@polsanz.xyz",
@@ -12,7 +12,8 @@ setup(
     packages=find_packages("src"),
     entry_points={
         "aiida.calculations": [
-            "mace-train = MatDBForge.workflows.active_learning:TrainMACEModelCalculation"
+            "mace-train = MatDBForge.active_learning.mace_tools_aiida:TrainMACEModelCalculation",
+            "mace-get-descriptors = MatDBForge.active_learning.mace_tools_aiida:GetMACEDescriptorsCalculation"
         ],
         "aiida.calculations.monitors": [
             "monitor.davwarning = MatDBForge.workflows.monitors:output_monitor"
@@ -22,7 +23,8 @@ setup(
             "mdb-active-learning-base = MatDBForge.workflows.active_learning:ActiveLearningBaseWorkChain",
         ],
         "aiida.parsers": [
-            "mace-training-parser = MatDBForge.workflows.active_learning:TrainMACEModelCalculationParser",
+            "mace-training-parser = MatDBForge.active_learning.mace_tools_aiida:TrainMACEModelCalculationParser",
+            "mace-descriptors-parser = MatDBForge.active_learning.mace_tools_aiida:GetMACEDescriptorsCalculationParser",
         ],
         "console_scripts": [
             "mdb_active_learning=MatDBForge.core.command_line:run_active_learning",

--- a/src/MatDBForge/__init__.py
+++ b/src/MatDBForge/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.1"
+import pathlib as pl
+
+# Root of package
+ROOT_DIR = (pl.Path(__file__).parent).resolve()
+
+__version__ = "0.2"

--- a/src/MatDBForge/active_learning/active_learning_utils.py
+++ b/src/MatDBForge/active_learning/active_learning_utils.py
@@ -156,21 +156,33 @@ def get_dft_calc_builder(struct, row, calc_idx, group):
 
     # HACK
     # TODO: Move this to the central TOML file.
+    # kspacing_dict = {
+    #     "alpha": 0.135088484104361,
+    #     # "m1": 0.100530964914873,
+    #     "beta-prime": 0.102415920507027,
+    #     # "m2": 0.100530964914873,
+    #     "gamma": 0.141371669411541,
+    #     # "m3": 0.166504410640259,
+    #     "epsilon": 0.105557513160617,
+    #     "eta": 0.0993371597065093,
+    #     # "m4": 0.0948760981384118,
+    #     "delta": 0.0994491889005363,
+    # }
+    # TESTING
     kspacing_dict = {
-        "alpha": 0.135088484104361,
-        # "m1": 0.100530964914873,
-        "beta-prime": 0.102415920507027,
-        # "m2": 0.100530964914873,
-        "gamma": 0.141371669411541,
-        # "m3": 0.166504410640259,
-        "epsilon": 0.105557513160617,
-        "eta": 0.0993371597065093,
-        # "m4": 0.0948760981384118,
-        "delta": 0.0994491889005363,
+        "alpha": 0.9,
+        # "m1": 0.9,
+        "beta-prime": 0.9,
+        # "m2": 0.9,
+        "gamma": 0.9,
+        # "m3": 0.9,
+        "epsilon": 0.9,
+        "eta": 0.9,
+        # "m4": 0.9,
+        "delta": 0.9,
     }
-
     # REMOVE # TESTING
-    # vasp-std-5.4.4-new@tekla2-new-test
+    # vasp-std-5.4.4-new@tekla2
     # vasp-std-5.3.3-new@tekla2-updated-2024
     # ################
     # HACK
@@ -178,39 +190,42 @@ def get_dft_calc_builder(struct, row, calc_idx, group):
     queue_dict = {
         2: {
             "type": "sge",
-            "node_cpus": 48,
+            "node_cpus": 12,
             "code_string": "vasp-std-5.4.4-new@tekla2",
             "options_resources": {
-                "parallel_env": "c48m256ib_mpi",
-                "tot_num_mpiprocs": 48,
+                "parallel_env": "c12m48ib_mpi",
+                "tot_num_mpiprocs": 12,
             },
             "multiple": 1,
         },
         5: {
             "type": "sge",
-            "node_cpus": 48,
+            "node_cpus": 12,
             "code_string": "vasp-std-5.4.4-new@tekla2",
             "options_resources": {
-                "parallel_env": "c48m256ib_mpi",
-                "tot_num_mpiprocs": 48,
+                "parallel_env": "c12m48ib_mpi",
+                "tot_num_mpiprocs": 12,
             },
             "multiple": 1,
         },
         40: {
             "type": "sge",
-            "node_cpus": 48,
+            "node_cpus": 12,
             "code_string": "vasp-std-5.4.4-new@tekla2",
             "options_resources": {
-                "parallel_env": "c48m256ib_mpi",
-                "tot_num_mpiprocs": 48,
+                "parallel_env": "c12m48ib_mpi",
+                "tot_num_mpiprocs": 12,
             },
             "multiple": 1,
         },
     }
 
-    # TESTING # potential_family = "vasp-5.3-PBE"
     # HACK
     # TODO: Move this to the central TOML file.
+    # potential_family = "vasp-5.4-PBE-2023"
+    # potential_family = "vasp-5.3-PBE"
+
+    # TESTING
     potential_family = "vasp-5.4-PBE-2023"
     potential_mapping = mdb_aut.generate_potential_mapping()
 
@@ -294,7 +309,7 @@ def load_mace_settings_json(
     if isinstance(settings_path, Str):
         settings_path = settings_path.value
 
-    with open(settings_path, "r") as f:
+    with open(settings_path) as f:
         training_settings_dict = json.load(f)
 
     # Update training file path in mace train settings
@@ -379,7 +394,7 @@ def aiida_serialized_ase_dict_to_atoms(struct_dict: dict) -> Atoms:
         if key != "pbc" and isinstance(val, list):
             struct_dict[key] = np.array(val)
 
-    if "info" in struct_dict.keys():
+    if "info" in struct_dict:
         for key, val in struct_dict["info"].items():
             if key != "pbc" and isinstance(val, list):
                 struct_dict["info"][key] = np.array(val)
@@ -416,7 +431,7 @@ def gather_dft_calcs(dft_calc_list: list) -> List:
     input. Specifically, it converts VASP runs into ASE Atoms objects and collects
     additional calculation data like forces. It also augments the Atoms objects with
     metadata necessary for the active learning workflow. Failed calculations are skipped
-    ensuring that only successfully completed calculations are included.
+    ensuring that only successfully completed CalcJobs are included.
     The function returns a list of serialized ASE Atoms objects, ready for inclusion
     in the active learning database.
 
@@ -439,9 +454,10 @@ def gather_dft_calcs(dft_calc_list: list) -> List:
     - Extra care is taken to include forces (and optionally, stress) in the Atoms objects,
     as these are critical for many active learning applications but are not included by
     default in the extxyz format's `Properties` tag.
-    - Skips any DFT calculations that encountered errors..
+    - Skips any DFT calculations that encountered errors.
     """
     vasprun_list = []
+
     # Adding structures to the initial DB
     for finished_dft_calc in dft_calc_list:
         finished_dft_calc = load_node(finished_dft_calc)
@@ -483,7 +499,7 @@ def gather_dft_calcs(dft_calc_list: list) -> List:
         calc_info_dict["mdb_struct_type"] = struct_type
         vasprun = vasprun_add_info_dict(vasprun, calc_info_dict)
 
-        # Using this function to generate a structure name and gathering the aiida_uuid.
+        # Generate a structure name and gathering the aiida_uuid
         vasprun: Atoms = mdb_conv._add_entry_to_mace_input(
             vasprun=vasprun,
             node=finished_dft_calc,

--- a/src/MatDBForge/active_learning/conversion.py
+++ b/src/MatDBForge/active_learning/conversion.py
@@ -428,6 +428,6 @@ def gen_mace_train_structure_list(
         # Writing the file
         aseio.write(path, ase_structs, "extxyz")
 
-    # REMOVE
-    else:
-        print("Path already exists, not overwriting final db.")
+    # # REMOVE
+    # else:
+    #     print("Path already exists, not overwriting final db.")

--- a/src/MatDBForge/core/__init__.py
+++ b/src/MatDBForge/core/__init__.py
@@ -1,7 +1,7 @@
 import pathlib as pl
 
-# Root directory (actually 'core' directory)
-ROOT_DIR = (pl.Path(__file__).parent).resolve()
+# Core directory
+CORE_DIR = (pl.Path(__file__).parent).resolve()
 
 # Data folder
 DATA_DIR = (pl.Path(__file__).parent.parent / "data").resolve()

--- a/src/MatDBForge/core/command_line.py
+++ b/src/MatDBForge/core/command_line.py
@@ -47,6 +47,7 @@ def create_active_learning_builder(toml_dict: dict):
     builder.active_learning.md_num_steps = int(al_conf["md_num_steps"])
     builder.active_learning.md_timestep_duration_ps = float(al_conf["md_timestep_duration_ps"])
     builder.active_learning.commitee_num_models = int(al_conf["commitee_num_models"])
+    builder.active_learning.check_extrapolation = al_conf["check_extrapolation"]
     builder.active_learning.model_acc_multiplier = float(
         al_conf["model_acc_multiplier"]
     )

--- a/src/MatDBForge/data/input_files/active_learning_settings.toml
+++ b/src/MatDBForge/data/input_files/active_learning_settings.toml
@@ -1,108 +1,119 @@
 # Active Learning Settings
 [active_learning]
 
-# Name of the aiida profile to be used
-aiida_profile = ""
+    # Name of the aiida profile to be used
+    aiida_profile = ""
 
-# Path to the folder where the initial database is contained.
-data_path = ""
+    # Path to the folder where the initial database is contained.
+    data_path = ""
 
-# Path to the folder where the initial database is contained.
-init_db_path = ""
+    # Path to the folder where the initial database is contained.
+    init_db_path = ""
 
-# Path for final results. Will be created if not existent.
-# It will contain a folder named run_{uuid}.
-results_dir = ""
+    # Path for final results. Will be created if not existent.
+    # It will contain a folder named run_{uuid}.
+    results_dir = ""
 
-# Name for the final database
-# The database will be stored in the extxyz format
-final_db_name = "final_data_test"
+    # Name for the final database
+    # The database will be stored in the extxyz format
+    final_db_name = "final_data_test"
 
-# Maximum number of AL loop iterations.
-max_iterations = 3
+    # Maximum number of AL loop iterations.
+    max_iterations = 3
 
-# Sets total structures in AL seed as a function of the training db size.
-# This influences the amount of MD calculations and E, F evaluations.
-seed_size_frac = 0.01
+    # Sets total structures in AL seed as a function of the training db size.
+    # This influences the amount of MD calculations and E, F evaluations.
+    seed_size_frac = 0.01
 
-# MD temperature.
-md_temperature_K = 300.0
+    # MD temperature.
+    md_temperature_K = 300.0
 
-# Total number of timesteps for the MD simulations
-md_num_steps = 1000
+    # Total number of timesteps for the MD simulations
+    md_num_steps = 1000
 
-# Duration of each timestep.
-md_timestep_duration_ps = 0.003
+    # Duration of each timestep.
+    md_timestep_duration_ps = 0.003
 
-# Total number of MACE models. 
-# Increases resources necessary for training.
-commitee_num_models = 4
+    # Total number of MACE models. 
+    # Increases resources necessary for training.
+    commitee_num_models = 4
 
-# Multiplier for model accuracy. Loosens model accuracy threshold.
-# Tighter thresholds will result in more DFT calculations.
-# Any RMSE E/F values above chem_acc*chem_acc_multiplier will be considered wrong.
-model_acc_multiplier = 10
+    # Multiplier for model accuracy. Loosens model accuracy threshold.
+    # Tighter thresholds will result in more DFT calculations.
+    # Any RMSE E/F values above chem_acc*chem_acc_multiplier will be considered wrong.
+    model_acc_multiplier = 10
 
-# Every how many ps of MD simulation keep a structure. 
-# Influences the total number of energy evaluations and possibly DFT calculations.
-al_keep_struct_every_n_ps = 1
+    # Every how many ps of MD simulation keep a structure. 
+    # Influences the total number of energy evaluations and possibly DFT calculations.
+    al_keep_struct_every_n_ps = 1
+
+    # Whether to check for extrapolation using the MACE descriptors
+    check_extrapolation = true
+
 
 # MACE training code and scheduler settings (aiida)
 [mace_train]
-code = "mace_run_train_gpu@tekla2-new-test"
-metadata.options.resources.parallel_env = "c128m1024ib_mpi_32slots"
-metadata.options.resources.tot_num_mpiprocs = 32
-metadata.options.parser_name = "mace-training-parser"
-metadata.options.queue_name = "c128m1024ibgpu4.q"
-metadata.options.max_wallclock_seconds = 117280000
-metadata.options.max_memory_kb = 102400000
-metadata.options.withmpi = true
-metadata.options.custom_scheduler_commands = '''#$ -l gpu=1
-#$ -l hostname="tekla2188"'''
-result_force_weight = 0.1
 
-# MACE Training Settings (run_mace_train)
-[mace_train.train_settings]
-name = "nnp_training_test"
-energy_key = "free_energy"
-valid_fraction = 0.1
-config_type_weights = { Default = 1.0 }
-weight_decay = 9.34e-07
-E0s = "average"
-num_interactions = 2
-model = "MACE"
-correlation = 3
-hidden_irreps = "16x0e + 16x1o"
-lr = 0.005626773506534471
-r_max = 6.0
-max_ell = 3
-max_L = 2
-batch_size = 64
-max_num_epochs = 30
-swa = true
-ema = true
-ema_decay = 0.99
-amsgrad = true
-restart_latest = true
-device = "cuda"
-default_dtype = "float32"
-wandb = false
+    # Weight of the force when considering model performance, used in:
+    # weighted_sum = RMSE_E + (force_weight * RMSE_F)
+    # The lowest weighted_sum will be considered as the most performant model.
+    result_force_weight = 0.1
+
+    # Scheduler options for MACE Training
+    code = "mace_run_train_gpu@tekla2-new-test"
+    metadata.options.resources.parallel_env = "c128m1024ib_mpi_32slots"
+    metadata.options.resources.tot_num_mpiprocs = 32
+    metadata.options.parser_name = "mace-training-parser"
+    metadata.options.queue_name = "c128m1024ibgpu4.q"
+    metadata.options.max_wallclock_seconds = 117280000
+    metadata.options.max_memory_kb = 102400000
+    metadata.options.withmpi = true
+    metadata.options.custom_scheduler_commands = '''#$ -l gpu=1
+    #$ -l hostname="tekla2188"'''
+
+    # MACE Training Settings (run_mace_train)
+    [mace_train.train_settings]
+    name = "nnp_training_test"
+    energy_key = "free_energy"
+    valid_fraction = 0.1
+    config_type_weights = { Default = 1.0 }
+    weight_decay = 9.34e-07
+    E0s = "average"
+    num_interactions = 2
+    model = "MACE"
+    correlation = 3
+    hidden_irreps = "16x0e + 16x1o"
+    lr = 0.005626773506534471
+    r_max = 6.0
+    max_ell = 3
+    max_L = 2
+    batch_size = 64
+    max_num_epochs = 30
+    swa = true
+    ema = true
+    ema_decay = 0.99
+    amsgrad = true
+    restart_latest = true
+    device = "cuda"
+    default_dtype = "float32"
+    wandb = false
+
 
 # LAMMPS-MACE MD Settings (aiida)
 [lammps_mace]
-code = "mace-lammps-gpu@tekla2-updated-2024"
-metadata.options.resources.parallel_env = "c128m1024ib_mpi_32slots"
-metadata.options.resources.tot_num_mpiprocs = 4
-metadata.options.queue_name = "c128m1024ibgpu4.q"
-metadata.options.max_memory_kb = 102400000
-metadata.options.max_wallclock_seconds = 117280000
-metadata.options.withmpi = false
-metadata.options.custom_scheduler_commands = "#$ -l gpu=1"
-gather_traj_cnt_lattice = true
+    code = "mace-lammps-gpu@tekla2-updated-2024"
+    metadata.options.resources.parallel_env = "c128m1024ib_mpi_32slots"
+    metadata.options.resources.tot_num_mpiprocs = 4
+    metadata.options.queue_name = "c128m1024ibgpu4.q"
+    metadata.options.max_memory_kb = 102400000
+    metadata.options.max_wallclock_seconds = 117280000
+    metadata.options.withmpi = false
+    metadata.options.custom_scheduler_commands = "#$ -l gpu=1"
+    gather_traj_cnt_lattice = true
 
 # Committee Evaluation Settings (MACE)
 [committee_eval]
-device = "cuda"
-dtype = "float32"
-batch_size = 64
-compute_stress = true
+    device = "cuda"
+    dtype = "float32"
+    batch_size = 64
+    compute_stress = true

--- a/src/MatDBForge/workflows/active_learning.py
+++ b/src/MatDBForge/workflows/active_learning.py
@@ -131,10 +131,8 @@ class ActiveLearningWorkChain(WorkChain):
             # The original structure will be removed from D0, or
             # The problematic structure will be calcualated using DFT
             cls.send_calc_or_remove_structures,
-
             # Return the generated DFT calculations to the workchain as an output
             cls.return_seed_dft,
-
             # TODO: If high error (define this) is found on a training seed,
             # do not change seed until the error is decreased
             # cls.choose_next_seed,
@@ -193,7 +191,7 @@ class ActiveLearningWorkChain(WorkChain):
             "current iteration data."
         )
 
-        for model_num in range(self.inputs.commitee_num_models.value):
+        for _ in range(self.inputs.commitee_num_models.value):
             model_name = mdb_al.generate_model_name()
 
             # Load training settings from inputs and update path and model names.
@@ -319,7 +317,6 @@ class ActiveLearningWorkChain(WorkChain):
         self.ctx.commitee_models_tupl_name_uuid = commitee_models_tupl_name_uuid
 
     def check_extrapolation_enabled(self):
-        print('self.inputs.check_extrapolation: ', self.inputs.check_extrapolation)
         return self.inputs.check_extrapolation
 
     def generate_descriptors(self):
@@ -352,7 +349,6 @@ class ActiveLearningWorkChain(WorkChain):
         )
         mace_builder.mace_train_file_path = str(mace_train_file_path)
         descriptor_code_path = Path(f"{ROOT_DIR}/active_learning/mace_code")
-        print("descriptor_code_path: ", descriptor_code_path)
         code = PortableCode(
             label="mace_get_descriptors",
             filepath_files=descriptor_code_path,
@@ -624,8 +620,6 @@ class ActiveLearningWorkChain(WorkChain):
             workchain_results = workchain.outputs.retrieved
             steps_E_F_arr = self.gather_energies_from_workchain(workchain_results)
             traj, forces = self.gather_traj_from_workchain(workchain_results)
-            print("before traj: ", len(traj))
-            print("before select md frames to keep steps_E_F_arr: ", len(steps_E_F_arr))
 
             # Instead of keeping all frames, select some of them
             # Get 1 frame every n picoseconds of MD simulation
@@ -637,8 +631,6 @@ class ActiveLearningWorkChain(WorkChain):
                 steps_E_F_arr=steps_E_F_arr,
                 forces=forces,
             )
-            print("after traj: ", len(traj))
-            print("after select md frames to keep steps_E_F_arr: ", len(steps_E_F_arr))
 
             new_rows.append(
                 {
@@ -939,10 +931,10 @@ class ActiveLearningWorkChain(WorkChain):
             traj_frames = []
 
             for frame in curr_traj:
-                curr_frame:Atoms = AseAtomsAdaptor.get_atoms(frame)
-                curr_frame.info['aiida_uuid'] = row["unique_id"]
+                curr_frame: Atoms = AseAtomsAdaptor.get_atoms(frame)
+                curr_frame.info["aiida_uuid"] = row["unique_id"]
                 traj_frames.append(curr_frame)
-    
+
             all_frames_list.extend(traj_frames)
 
         # Write xyz file into a string captured in the stdout,
@@ -1026,34 +1018,31 @@ class ActiveLearningWorkChain(WorkChain):
                     md_descr_dict: list[list[list]] = pickle.load(descr_file)
                     # md_descr_array: np.ndarray = np.load(file=md_descr_file_path)
 
-            
-            extrapolation_column_list: list[dict[str,list]] = []
+            extrapolation_column_list: list[dict[str, list]] = []
             for _, row in self.ctx.md_seed_results_df.iterrows():
-                df_uuid = row['unique_id']
-                desc_f_curr_row:list = md_descr_dict[df_uuid]
+                df_uuid = row["unique_id"]
+                desc_f_curr_row: list = md_descr_dict[df_uuid]
                 # print('desc_f_curr_row: ', len(desc_f_curr_row))
                 # print('desc_f_curr_row: ', desc_f_curr_row.shape)
                 # descriptor_arr = np.vstack(desc_f_curr_row)
                 # print('descriptor_arr: ', descriptor_arr.shape)
                 # extrapolation_column_list.append({'m0': descriptor_arr})
-                extrapolation_column_list.append({'m0': desc_f_curr_row})
+                extrapolation_column_list.append({"m0": desc_f_curr_row})
 
-            self.ctx.md_seed_results_df['extrapolation'] = extrapolation_column_list
+            self.ctx.md_seed_results_df["extrapolation"] = extrapolation_column_list
 
         # Every row contains the results of MD for a single structure, which are:
         # trajectory, energies, forces, al_step, index_in_db, mdb_struct_type,
         # cluster, material_name, unique_id
         for _, row in self.ctx.md_seed_results_df.iterrows():
-
             # Make len(traj) sized array filled with 'False'.
-            extrapolating_frames = np.zeros(shape=len(row['trajectory']))
+            extrapolating_frames = np.zeros(shape=len(row["trajectory"]))
 
             if self.inputs.check_extrapolation:
-                curr_struct_descr = row['extrapolation']['m0']
+                curr_struct_descr = row["extrapolation"]["m0"]
 
                 # Checking if the frames for the current structure are extrapolating
                 for frame_idx, frame_descriptors in enumerate(curr_struct_descr):
-
                     below_min = frame_descriptors < self.ctx.descriptors_min_array
                     above_max = frame_descriptors > self.ctx.descriptors_max_array
                     is_frame_extrapolating = np.any(np.logical_or(below_min, above_max))
@@ -1113,7 +1102,8 @@ class ActiveLearningWorkChain(WorkChain):
                     row["trajectory"][int(struct)] for struct in selected_high_error
                 ]
 
-                # REMOVE: For testing purposes. Remove this!
+                # REMOVE: For testing purposes.
+                # TESTING
                 # dft_structures = [row["trajectory"][5]]
 
                 for calc_idx, dft_struct in enumerate(dft_structures):
@@ -1162,14 +1152,16 @@ class ActiveLearningWorkChain(WorkChain):
         try:
             dft_calcs = len(self.ctx.dft_struct_seed_calcs)
             self.report(f"Gathered {dft_calcs} DFT calculations.")
+
+            return_list = mdb_al.gather_dft_calcs(
+                [node.uuid for node in self.ctx.dft_struct_seed_calcs]
+            )
+
         except AttributeError:
-            self.ctx.dft_struct_seed_calcs = []
+            # self.ctx.dft_struct_seed_calcs = []
+            return_list = List([])
 
-        return_list = mdb_al.gather_dft_calcs(
-            [node.uuid for node in self.ctx.dft_struct_seed_calcs]
-        )
-
-        self.out("dft_calcs", return_list)
+        self.out("dft_calcs", return_list)  # list[dict]
         self.out(
             "stop_md_seed_no_disagreement",
             mdb_al.check_md_seed_agreement(return_list),
@@ -1226,7 +1218,7 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
                 # Check for correct results
                 # cls.inspect_process,
                 # Get results from workchain
-                cls.results_loop,
+                cls.get_results_loop,
                 # Update Ds and Di to include results from DFT.
                 # Update the inputs for the next workchain.
                 cls.add_dft_results_to_db,
@@ -1280,12 +1272,13 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             f"Loaded initial database containing {len(database_training)} structures."
         )
 
-    def results_loop(self):
+    def get_results_loop(self):
         """Attach the outputs specified in the spec from the last completed process."""
         node = self.ctx.children[self.ctx.iteration - 1]
 
         # TODO: Gather outputs manually, instead of using __attach_outputs
         self._attach_outputs(node)
+        self.ctx.last_workchain_completed = node
         return None
 
     def add_dft_results_to_db(self):
@@ -1303,8 +1296,11 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
         # self.ctx.seed_gen_db = self.outputs["upd_seed_gen_db"]
         # self.ctx.inputs.seed_gen_db = self.outputs["upd_seed_gen_db"]
 
+        last_wc = self.ctx.last_workchain_completed
+
         try:
-            cnt_dft_calcs = len(self.outputs["dft_calcs"])
+            cnt_dft_calcs = len(last_wc.outputs["dft_calcs"])
+
         except KeyError:
             cnt_dft_calcs = 0
 
@@ -1312,7 +1308,7 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             self.report(f"Adding {cnt_dft_calcs} DFT calculations to DB.")
 
             # Adding calculations to training database and seed_generation database
-            for dft_calc in self.outputs["dft_calcs"]:
+            for dft_calc in last_wc.outputs["dft_calcs"]:
                 # Converting serialized structures to Atoms object.
                 if isinstance(dft_calc, dict):
                     dft_calc = mdb_al.aiida_serialized_ase_dict_to_atoms(dft_calc)

--- a/src/MatDBForge/workflows/active_learning.py
+++ b/src/MatDBForge/workflows/active_learning.py
@@ -1,22 +1,22 @@
 """Definition of an aiida workchain for MACE active learning loops using MD."""
 
 import io
-import json
+import pickle
 import re
 import shutil
 import time
+from contextlib import redirect_stdout, suppress
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pymatgen.io.ase as pmg_ase
 import torch
-from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.engine import (
     BaseRestartWorkChain,
-    CalcJob,
     WorkChain,
     append_,
+    if_,
     while_,
 )
 from aiida.orm import (
@@ -27,170 +27,30 @@ from aiida.orm import (
     Group,
     Int,
     List,
+    PortableCode,
     SinglefileData,
     Str,
     load_code,
+    load_computer,
     load_group,
     load_node,
     to_aiida_type,
 )
-from aiida.parsers.parser import Parser
 from aiida.plugins import CalculationFactory
 from ase import Atoms
 from ase.io import read as ase_read
 from ase.io import write as ase_write
 from mace import data as mace_data
 from mace import tools as mace_tools
-from mace.calculators import MACECalculator
 from pymatgen.core import Structure
 from pymatgen.core.trajectory import Trajectory
 from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.io.lammps.data import LammpsData
 
+from MatDBForge import ROOT_DIR
 from MatDBForge.active_learning import active_learning_utils as mdb_al
 from MatDBForge.active_learning import conversion as mdb_conv
 from MatDBForge.core import DATA_DIR
-
-
-class TrainMACEModelCalculationParser(Parser):
-    def parse(self, **kwargs):
-        """Parse the retrieved files of the calculation job."""
-        # str that represents the absolute filepath to the temporary folder
-        retrieved_temporary_folder: Path = Path(kwargs["retrieved_temporary_folder"])
-
-        for child_file in retrieved_temporary_folder.iterdir():
-            # create singlefile data for the model
-            if "swa.model" in child_file.name:
-                model_file = SinglefileData(file=child_file)
-
-            if "train.txt" in child_file.name:
-                # TODO: gather rmse_e, rmse_f
-                with open(child_file) as f:
-                    for line in f:
-                        line_dict = json.loads(line)
-                        if "rmse_e" in line_dict.keys():
-                            last_dict = line_dict
-
-                rmse_e = float(last_dict["rmse_e_per_atom"]) * 1000  # meV / atom
-                rmse_f = float(last_dict["rmse_f"]) * 1000  # meV / A
-
-        # Return CalcJob outputs
-        self.out("model_file", model_file)
-        self.out("m_rmse_e", Float(rmse_e))
-        self.out("m_rmse_f", Float(rmse_f))
-
-
-class TrainMACEModelCalculation(CalcJob):
-    """Implementation of CalcJob to perform a MACE training using a settings dir."""
-
-    @classmethod
-    def define(cls, spec):
-        super().define(spec)
-        spec.input(
-            "mace_settings_dict",
-            valid_type=Dict,
-            help="Dictionary containing MACE training settings.",
-        )
-        spec.input(
-            "mace_train_file_path",
-            valid_type=Str,
-            help=(
-                "Path to the file containing the structures to be used for training, "
-                "in the extxyz format."
-            ),
-            # non_db=True,
-            serializer=to_aiida_type,
-        )
-        spec.input(
-            "test_file",
-            valid_type=SinglefileData,
-            help=(
-                "File containing the structures to be used for training, "
-                "in the extxyz format."
-            ),
-            required=False,
-            default=None,
-        )
-
-        spec.input(
-            "model_name",
-            valid_type=Str,
-            help=("Name given to the model."),
-            serializer=to_aiida_type,
-        )
-
-        spec.output(
-            "model_file",
-            valid_type=SinglefileData,
-            help="Path of the trained MACE model.",
-        )
-        spec.output(
-            "m_rmse_e",
-            valid_type=Float,
-            help="Validation RMSE for the energy, in meV / atom.",
-        )
-        spec.output(
-            "m_rmse_f",
-            valid_type=Float,
-            help="Validation RMSE for the forces, in meV / Å.",
-        )
-
-    def prepare_for_submission(self, folder):
-        """Write the input files that are required for the code to run.
-
-        :param folder: an `~aiida.common.folders.Folder` to temporarily write files on disk
-        :return: `~aiida.common.datastructures.CalcInfo` instance
-        """
-        # Parsing mace settings dict
-        # TODO: Add a way of checking if validation_file was given.
-        params_list = []
-        for key, val in self.inputs.mace_settings_dict.items():
-            if key == "train_file":
-                val = Path(val).resolve().name
-
-            if isinstance(val, str):
-                curr_key = f"--{key}={val}"
-            elif isinstance(val, bool):
-                if val:
-                    curr_key = f"--{key}"
-            else:
-                curr_key = f"--{key}={val}"
-            params_list.append(curr_key)
-
-        # Adding random seed
-        params_list.append(f"--seed={np.random.randint(1, 100000000)}")
-
-        # Copying database to temporary folder
-        final_db_path = self.inputs.mace_train_file_path.value
-        folder.insert_path(
-            src=final_db_path,
-            dest_name=self.inputs.mace_settings_dict["train_file"],
-        )
-
-        codeinfo = CodeInfo()
-        codeinfo.code_uuid = self.inputs.code.uuid
-        codeinfo.stdout_name = self.options.output_filename
-        codeinfo.cmdline_params = params_list
-
-        calcinfo = CalcInfo()
-        calcinfo.codes_info = [codeinfo]
-        calcinfo.local_copy_list = []
-        calcinfo.provenance_exclude_list = [
-            self.inputs.mace_settings_dict["train_file"]
-        ]
-        calcinfo.remote_copy_list = []
-
-        # Gathering files. They won't be added to the repository,
-        # and instead kept into a temporary folder.
-        # They can later be processed during the parse function
-        # by accessing the temporary folder.
-        calcinfo.retrieve_temporary_list = [
-            self.metadata.options.output_filename,
-            "./*.model",
-            "./results/*",
-        ]
-
-        return calcinfo
 
 
 class ActiveLearningWorkChain(WorkChain):
@@ -240,6 +100,7 @@ class ActiveLearningWorkChain(WorkChain):
         )
         spec.input("lammps_mace", valid_type=Dict)
         spec.input("committee_eval", valid_type=Dict)
+        spec.input("check_extrapolation", valid_type=Bool, serializer=to_aiida_type)
 
         spec.outline(
             # Training the main mace model (M0) and the commitee models
@@ -247,6 +108,13 @@ class ActiveLearningWorkChain(WorkChain):
             cls.train_mace_model,
             # Gathering results from mace training.
             cls.get_mace_train_output,
+            if_(cls.check_extrapolation_enabled)(
+                # Generate MACE descriptors for the current seed.
+                cls.generate_descriptors,
+                # Gather the descriptors from the calcjob and store them
+                # in the workchain context.
+                cls.get_mace_descriptors_output,
+            ),
             # All of the structures in the seed will be run using the MD
             # code selected, using the main model (M0)
             cls.run_md_seed,
@@ -255,13 +123,19 @@ class ActiveLearningWorkChain(WorkChain):
             cls.gather_m0_md_results,
             # The structures from M0 will be evaluated using M1, M2 and M3.
             cls.check_commitee_results,
+            if_(cls.check_extrapolation_enabled)(
+                # Getting MACE descriptors for the structures obtained with MD.
+                cls.get_descriptors_from_md_results,
+            ),
             # According to the difference in error between the models either:
             # The original structure will be removed from D0, or
             # The problematic structure will be calcualated using DFT
             cls.send_calc_or_remove_structures,
+
+            # Return the generated DFT calculations to the workchain as an output
             cls.return_seed_dft,
-            # TODO:
-            # If high error (define this) is found on a training seed,
+
+            # TODO: If high error (define this) is found on a training seed,
             # do not change seed until the error is decreased
             # cls.choose_next_seed,
         )
@@ -401,7 +275,7 @@ class ActiveLearningWorkChain(WorkChain):
 
         # Get the most accurate model name during the validation by checking
         # the lowest E+F*weight.
-        best_model_name = model_name_list[np.argmin(weighted_E_F_sum_list)]
+        self.ctx.best_model_name = model_name_list[np.argmin(weighted_E_F_sum_list)]
 
         commitee_models_tupl_name_uuid = []
         for idx, calc in enumerate(mace_training_results):
@@ -416,7 +290,7 @@ class ActiveLearningWorkChain(WorkChain):
 
             # Use checking if the currentt case is the best model.
             # Saving model results
-            if model_name == best_model_name:
+            if model_name == self.ctx.best_model_name:
                 # Overwriting m0_rmse values with actual training values
                 self.ctx.m0_rmse_e = curr_calc.outputs.m_rmse_e
                 self.ctx.m0_rmse_f = curr_calc.outputs.m_rmse_f
@@ -443,6 +317,90 @@ class ActiveLearningWorkChain(WorkChain):
 
         # Sending commitee model paths to current context
         self.ctx.commitee_models_tupl_name_uuid = commitee_models_tupl_name_uuid
+
+    def check_extrapolation_enabled(self):
+        print('self.inputs.check_extrapolation: ', self.inputs.check_extrapolation)
+        return self.inputs.check_extrapolation
+
+    def generate_descriptors(self):
+        self.report("Generating descriptors...")
+
+        for _, calc in enumerate(self.ctx.mace_training_results):
+            # Loading calculation node
+            curr_calc = load_node(calc.uuid)
+
+            # Getting model name
+            model_name = curr_calc.inputs.model_name.value
+
+            # Using the best model
+            if model_name == self.ctx.best_model_name:
+                best_calc = curr_calc
+                break
+
+        # Getting model file
+        self.ctx.best_model_file = best_calc.outputs.model_file
+
+        # Prepare GetMACEDescriptorsCalculation
+        mace_descr_calc = CalculationFactory("mace-get-descriptors")
+        mace_builder = mace_descr_calc.get_builder()
+        mace_builder.model_file = self.ctx.best_model_file
+
+        mace_train_file_path, _ = mdb_al.get_final_db_path(
+            result_dir_path=self.inputs.results_dir.value,
+            final_db_name=self.inputs.final_db_name.value,
+            node=self.node,
+        )
+        mace_builder.mace_train_file_path = str(mace_train_file_path)
+        descriptor_code_path = Path(f"{ROOT_DIR}/active_learning/mace_code")
+        print("descriptor_code_path: ", descriptor_code_path)
+        code = PortableCode(
+            label="mace_get_descriptors",
+            filepath_files=descriptor_code_path,
+            filepath_executable="./mace_get_descriptors.py",
+            # TODO: Add to TOML
+            prepend_text="source /gpuscratch/psanz/mace/mace-venv/bin/activate",
+        )
+        mace_builder.code = code
+
+        # TODO: Add to TOML
+        mace_builder.metadata.options = {
+            "resources": {
+                "parallel_env": "c128m1024ib_mpi_32slots",
+                "tot_num_mpiprocs": 4,
+            },
+            "queue_name": "c128m1024ibgpu4.q",
+            "max_memory_kb": 102400000,
+            "parser_name": "mace-descriptors-parser",
+            "max_wallclock_seconds": 117280000,
+            "withmpi": False,
+            "custom_scheduler_commands": "#$ -l gpu=1",
+        }
+        mace_builder.metadata.label = model_name + "_descriptors"
+        mace_builder.metadata.computer = load_computer("tekla2-new-test")
+
+        mace_builder.metadata.options.output_filename = (
+            f"descriptors_{model_name}_iter-{self.inputs.al_loop_iteration.value}"
+        )
+
+        future = self.submit(mace_builder)
+        self.to_context(mace_descriptor_results=append_(future))
+
+    def get_mace_descriptors_output(self):
+        mace_descriptor_results = self.ctx.mace_descriptor_results
+        for calc in mace_descriptor_results:
+            # Loading calculation node
+            curr_calc = load_node(calc.uuid)
+
+            # Storing results in context
+            self.ctx.descriptors_min_array = (
+                curr_calc.outputs.descriptors_min_array.get_array()
+            )
+
+            self.ctx.descriptors_max_array = (
+                curr_calc.outputs.descriptors_max_array.get_array()
+            )
+
+        self.report("Gathered descriptor ranges.")
 
     def gen_md_input(
         self,
@@ -483,7 +441,7 @@ class ActiveLearningWorkChain(WorkChain):
         - Future versions may include more dynamic options based on LAMMPS's extensive
         configurability.
         """
-        with open(f"{DATA_DIR}/input_files/input.lammps", "r") as f:
+        with open(f"{DATA_DIR}/input_files/input.lammps") as f:
             lammps_template = f.read()
 
         lammps_template = lammps_template.replace(
@@ -666,6 +624,8 @@ class ActiveLearningWorkChain(WorkChain):
             workchain_results = workchain.outputs.retrieved
             steps_E_F_arr = self.gather_energies_from_workchain(workchain_results)
             traj, forces = self.gather_traj_from_workchain(workchain_results)
+            print("before traj: ", len(traj))
+            print("before select md frames to keep steps_E_F_arr: ", len(steps_E_F_arr))
 
             # Instead of keeping all frames, select some of them
             # Get 1 frame every n picoseconds of MD simulation
@@ -677,6 +637,8 @@ class ActiveLearningWorkChain(WorkChain):
                 steps_E_F_arr=steps_E_F_arr,
                 forces=forces,
             )
+            print("after traj: ", len(traj))
+            print("after select md frames to keep steps_E_F_arr: ", len(steps_E_F_arr))
 
             new_rows.append(
                 {
@@ -967,6 +929,78 @@ class ActiveLearningWorkChain(WorkChain):
                         forces_list  # total_force_norm_per_frame
                     )
 
+    def get_descriptors_from_md_results(self):
+        # Getting descriptors for generated structures
+        # Store all frames from the trajectory into a list
+        all_frames_list = []
+        for _, row in self.ctx.md_seed_results_df.iterrows():
+            curr_traj = row["trajectory"]
+            traj_frames = [AseAtomsAdaptor.get_atoms(frame) for frame in curr_traj]
+            traj_frames = []
+
+            for frame in curr_traj:
+                curr_frame:Atoms = AseAtomsAdaptor.get_atoms(frame)
+                curr_frame.info['aiida_uuid'] = row["unique_id"]
+                traj_frames.append(curr_frame)
+    
+            all_frames_list.extend(traj_frames)
+
+        # Write xyz file into a string captured in the stdout,
+        # write it to a temporary file.
+        f = io.StringIO()
+        with redirect_stdout(f):
+            ase_write(
+                filename="-",
+                format="extxyz",
+                images=all_frames_list,
+            )
+        xyz_string = f.getvalue()
+
+        # Generating tmp file
+        md_xyz_file = SinglefileData(
+            file=io.BytesIO(str.encode(xyz_string)),
+            filename="md_db.xyz",
+        )
+
+        # Prepare GetMACEDescriptorsCalculation
+        mace_descr_calc = CalculationFactory("mace-get-descriptors")
+        mace_builder = mace_descr_calc.get_builder()
+        mace_builder.model_file = self.ctx.best_model_file
+        mace_builder.mace_train_file_path = md_xyz_file
+        descriptor_code_path = Path(f"{ROOT_DIR}/active_learning/mace_code")
+        code = PortableCode(
+            label="mace_get_descriptors",
+            filepath_files=descriptor_code_path,
+            filepath_executable="./mace_get_descriptors.py",
+            # TODO: Add to TOML
+            prepend_text="source /gpuscratch/psanz/mace/mace-venv/bin/activate",
+        )
+        mace_builder.code = code
+
+        # TODO: Add to TOML
+        mace_builder.metadata.options = {
+            "resources": {
+                "parallel_env": "c128m1024ib_mpi_32slots",
+                "tot_num_mpiprocs": 4,
+            },
+            "queue_name": "c128m1024ibgpu4.q",
+            "max_memory_kb": 102400000,
+            "parser_name": "mace-descriptors-parser",
+            "max_wallclock_seconds": 117280000,
+            "withmpi": False,
+            "custom_scheduler_commands": "#$ -l gpu=1",
+        }
+        mace_builder.metadata.label = self.ctx.best_model_name + "_md_descriptors"
+        mace_builder.metadata.computer = load_computer("tekla2-new-test")
+
+        mace_builder.metadata.options.output_filename = (
+            f"descriptors_{self.ctx.best_model_name}_iter"
+            f"-{self.inputs.al_loop_iteration.value}"
+        )
+
+        future = self.submit(mace_builder)
+        self.to_context(md_descriptor_results=append_(future))
+
     def send_calc_or_remove_structures(self):
         self.report("Deciding which structures to keep...")
 
@@ -980,10 +1014,54 @@ class ActiveLearningWorkChain(WorkChain):
         delete_indices = []
         dft_structures = []
 
+        if self.inputs.check_extrapolation:
+            for calc in self.ctx.md_descriptor_results:
+                # Loading calculation node
+                curr_calc = load_node(calc.uuid)
+
+                # Storing results in context
+                with curr_calc.outputs.descriptors_file.as_path() as md_descr_file_path, open(
+                    md_descr_file_path, "rb"
+                ) as descr_file:
+                    md_descr_dict: list[list[list]] = pickle.load(descr_file)
+                    # md_descr_array: np.ndarray = np.load(file=md_descr_file_path)
+
+            
+            extrapolation_column_list: list[dict[str,list]] = []
+            for _, row in self.ctx.md_seed_results_df.iterrows():
+                df_uuid = row['unique_id']
+                desc_f_curr_row:list = md_descr_dict[df_uuid]
+                # print('desc_f_curr_row: ', len(desc_f_curr_row))
+                # print('desc_f_curr_row: ', desc_f_curr_row.shape)
+                # descriptor_arr = np.vstack(desc_f_curr_row)
+                # print('descriptor_arr: ', descriptor_arr.shape)
+                # extrapolation_column_list.append({'m0': descriptor_arr})
+                extrapolation_column_list.append({'m0': desc_f_curr_row})
+
+            self.ctx.md_seed_results_df['extrapolation'] = extrapolation_column_list
+
         # Every row contains the results of MD for a single structure, which are:
         # trajectory, energies, forces, al_step, index_in_db, mdb_struct_type,
         # cluster, material_name, unique_id
         for _, row in self.ctx.md_seed_results_df.iterrows():
+
+            # Make len(traj) sized array filled with 'False'.
+            extrapolating_frames = np.zeros(shape=len(row['trajectory']))
+
+            if self.inputs.check_extrapolation:
+                curr_struct_descr = row['extrapolation']['m0']
+
+                # Checking if the frames for the current structure are extrapolating
+                for frame_idx, frame_descriptors in enumerate(curr_struct_descr):
+
+                    below_min = frame_descriptors < self.ctx.descriptors_min_array
+                    above_max = frame_descriptors > self.ctx.descriptors_max_array
+                    is_frame_extrapolating = np.any(np.logical_or(below_min, above_max))
+
+                    # Change to True the ones that are extrapolating.
+                    if is_frame_extrapolating:
+                        extrapolating_frames[frame_idx] = 1
+
             # Getting all energy predictions
             # TODO - For E and F: Do variance
             model_energies_dict = row["energy"]
@@ -1005,8 +1083,11 @@ class ActiveLearningWorkChain(WorkChain):
             )
 
             # Joining both error masks to get a single True/False array marking
-            # structures to be computed
-            error_all_structures = np.ma.mask_or(error_e_structures, error_f_structures)
+            # structures to be computed with True
+            error_all_structures = np.logical_or(
+                np.logical_or(error_e_structures, error_f_structures),
+                extrapolating_frames,
+            )
 
             # If all values in error_all_structures are false, delete the main
             # structure from D0.
@@ -1088,8 +1169,6 @@ class ActiveLearningWorkChain(WorkChain):
             [node.uuid for node in self.ctx.dft_struct_seed_calcs]
         )
 
-
-
         self.out("dft_calcs", return_list)
         self.out(
             "stop_md_seed_no_disagreement",
@@ -1142,9 +1221,6 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             while_(cls.check_al_loop_conditions)(
                 # Get random structures from Ds to generate the MD seed.
                 cls.get_training_seed,
-                # TODO: Implement this function correctly.
-                # Generate descriptors for the current seed.
-                # cls.generate_descriptors,
                 # Run training seed
                 cls.run_process,
                 # Check for correct results
@@ -1233,12 +1309,10 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             cnt_dft_calcs = 0
 
         if cnt_dft_calcs > 0:
-
             self.report(f"Adding {cnt_dft_calcs} DFT calculations to DB.")
 
             # Adding calculations to training database and seed_generation database
             for dft_calc in self.outputs["dft_calcs"]:
-
                 # Converting serialized structures to Atoms object.
                 if isinstance(dft_calc, dict):
                     dft_calc = mdb_al.aiida_serialized_ase_dict_to_atoms(dft_calc)
@@ -1268,7 +1342,6 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             f"training_db: {len(training_db)} entries"
         )
 
-
     def get_al_loop_break_conditions(self):
         """
         Evaluate and set conditions to potentially break the active learning loop.
@@ -1294,27 +1367,6 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             self.ctx.seed_gen_db_all_structs_removed = Bool(True)
         else:
             self.ctx.seed_gen_db_all_structs_removed = Bool(False)
-
-    def generate_descriptors(self):
-        self.report("Generating descriptors...")
-
-        # TODO: This does not work
-        model_path = (
-            self.inputs.active_learning.data_path.value + "/"
-            # + self.inputs.active_learning.mace_potential_names[0]
-        )
-        calculator = MACECalculator(
-            model_paths=model_path, device="cuda", default_dtype="float32"
-        )
-        descriptor_list = []
-
-        # TODO: Check what to use: database_training or seed_gen_db?
-        for struct in ...:
-            curr_struct_descriptors = calculator.get_descriptors(struct)
-            descriptor_list.append(curr_struct_descriptors)
-
-        np.vstack(descriptor_list)
-        self.ctx.database_descriptors = descriptor_list
 
     def setup(self):
         """Call BaseRestartWorkChain setup and create inputs dict in self.ctx.inputs.

--- a/src/MatDBForge/workflows/aiida_utils.py
+++ b/src/MatDBForge/workflows/aiida_utils.py
@@ -126,7 +126,7 @@ INCAR_SP = {
         "nelm": 60,
         # ionic steps:
         "ibrion": -1,
-        "nsw": 2,
+        "nsw": 1,
         "ediffg": -0.03,
         "isif": 2,
         "potim": 0.3,
@@ -335,6 +335,10 @@ def choose_queue_from_struct(structure, assign_dict: dict):
     OPTIONS["qos"] = queue_data.get("qos", None)
     OPTIONS["max_wallclock_seconds"] = queue_data.get("max_wallclock_seconds", None)
     OPTIONS["max_memory_kb"] = queue_data.get("max_memory_kb", None)
+
+    # TESTING
+    # REMOVE
+    OPTIONS["custom_scheduler_commands"] = '#$ -l hostname="tekla2044"'
 
     # Getting code string
     CODE_STRING = queue_data["code_string"]


### PR DESCRIPTION
Merge `extrapolation_basic` into master

This merge incorporates two significant changes from the `extrapolation_basic` branch, enhancing the workflow's functionality and reliability:

1. **Extrapolation Checking with MACE Descriptor**:
   This branch introduces structure extrapolation checking capabilities using the MACE descriptors. This feature can be enabled through the `check_extrapolation` flag in the TOML configuration file. This enhancement is aimed at improving predictive reliability and model integrity during the active learning cycles.

2. **Fix for Duplicate Entries in Database**:
   Fixed a critical issue where duplicates were found in the structures database after running a test active learning loop. This was due to the improper use of the `_attach_outputs` method in the `get_results_loop()` function, which was intended for `CalcJob` outputs and not for `WorkChain` outputs.


