### PR TITLE
17 mace dft

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="MatDBForge",
-    version="0.3.1",
+    version="0.3.3",
     description="MatDBForge",
     author="Pol Sanz",
     author_email="me@polsanz.xyz",
@@ -14,6 +14,7 @@ setup(
         "aiida.calculations": [
             "mace-train = MatDBForge.active_learning.mace_tools_aiida:TrainMACEModelCalculation",
             "mace-get-descriptors = MatDBForge.active_learning.mace_tools_aiida:GetMACEDescriptorsCalculation",
+            "mace-eval = MatDBForge.active_learning.mace_tools_aiida:EvaluateMACEConfigsCalculation",
         ],
         "aiida.calculations.monitors": [
             "monitor.davwarning = MatDBForge.workflows.monitors:output_monitor"
@@ -25,6 +26,7 @@ setup(
         "aiida.parsers": [
             "mace-training-parser = MatDBForge.active_learning.mace_tools_aiida:TrainMACEModelCalculationParser",
             "mace-descriptors-parser = MatDBForge.active_learning.mace_tools_aiida:GetMACEDescriptorsCalculationParser",
+            "mace-eval-parser = MatDBForge.active_learning.mace_tools_aiida:EvaluateMACEConfigsCalculationParser",
         ],
         "console_scripts": [
             "mdb_active_learning=MatDBForge.core.command_line:run_active_learning",

--- a/src/MatDBForge/active_learning/active_learning_utils.py
+++ b/src/MatDBForge/active_learning/active_learning_utils.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import wonderwords as ww
-from aiida.cmdline.utils import echo_info
 from aiida.engine import (
     calcfunction,
 )
@@ -16,8 +15,11 @@ from aiida.orm import (
     List,
     SinglefileData,
     Str,
+    StructureData,
+    load_code,
     load_node,
 )
+from aiida.plugins import CalculationFactory
 from ase import Atoms
 from ase.io import read as ase_read
 from ase.io import write as ase_write
@@ -144,7 +146,7 @@ def select_md_frames_to_keep(
     return traj_sampled, steps_E_F_arr_sampled, forces_sampled
 
 
-def get_dft_calc_builder(
+def get_dft_calc_builder_vasp(
     struct,
     row,
     calc_idx: int,
@@ -185,6 +187,49 @@ def get_dft_calc_builder(
         group=group,
     )
     return builder
+
+
+def get_dft_calc_builder_mace(
+    struct,
+    row,
+    calc_idx: int,
+    group,
+    dft_settings: dict,
+):
+    struct_type = row["mdb_struct_type"]
+
+    # Gathering row information
+    (curr_structure, curr_material_name, curr_unique_id, curr_phase) = (
+        mdb_aut.gather_calc_data_from_row(row, curr_structure=struct)
+    )
+
+    # Prepare GetMACEDescriptorsCalculation
+    # Generate builder
+    mace_descr_calc = CalculationFactory("mace-eval")
+    mace_builder = mace_descr_calc.get_builder()
+
+    mace_builder.mace_settings_dict = dft_settings["settings"]
+
+    # Load model
+    model = SinglefileData(dft_settings["mace_potential_path"])
+    mace_builder.model_file = model
+
+    # Load structure as StructureData
+    mace_builder.configuration_to_evaluate = StructureData(pymatgen=curr_structure)
+
+    # Get code and remove from settings dict
+    mace_builder.code = load_code(dft_settings["options"]["code_string"])
+    dft_settings["options"].pop("code_string")
+
+    # Load scheduler and resources options
+    mace_builder.metadata.options = dft_settings["options"]
+
+    # Generating label for the CalcJob
+    struct_formula = curr_structure.formula.replace(" ", "")
+    struct_name = f"{curr_material_name}-{struct_formula}-{calc_idx}_{struct_type}"
+    mace_builder.metadata.label = struct_name
+
+    return mace_builder
 
 
 def generate_model_name():
@@ -370,7 +415,7 @@ def prepare_output_final_training_db(training_db_path):
 
 
 @calcfunction
-def gather_dft_calcs(dft_calc_list: list) -> List:
+def gather_dft_calcs_vasp(dft_calc_list: list) -> List:
     """
     Collect and preprocess VASP DFT calculation results for active learning input.
 
@@ -462,6 +507,51 @@ def gather_dft_calcs(dft_calc_list: list) -> List:
         vasprun_list.append(vasprun)
 
     return_list = List([val for val in vasprun_list])
+    return return_list
+
+
+@calcfunction
+def gather_dft_calcs_mace(dft_calc_list: list) -> List:
+    """Collect and preprocess MACE DFT calculation results for active learning input."""
+    result_list = []
+
+    # Adding structures to the initial DB
+    for finished_dft_calc in dft_calc_list:
+        calc_node = load_node(finished_dft_calc)
+
+        try:
+            # Gathering the vasprun as an ASE Atoms object. This object won't
+            # collect automatically all of the extra information such as forces
+            # or energies, and must be collected using methods from ase.calc.u
+            struct_serial_dict = calc_node.outputs.configuration_result_dict.get_dict()
+
+        except Exception:
+            # If the calculation fails for any reason, skip it.
+            continue
+
+        # Gathering extra DFT calculation information from calculation
+        # and its extras
+        calc_info_dict = {
+            "name": calc_node.label + "_aiida-uuid_" + calc_node.uuid,
+            "mdb_calc_uuid": calc_node.extras["mdb_calc_uuid"],
+            "mdb_struct_type": calc_node.extras["mdb_struct_type"],
+        }
+
+        for key, val in calc_info_dict.items():
+            struct_serial_dict["info"][key] = val
+
+        # Renaming energy key
+        struct_serial_dict["info"]["energy"] = struct_serial_dict["info"].pop(
+            "mdb_mace_eval_energy"
+        )
+
+        # Renaming forces dict
+        struct_serial_dict["forces"] = struct_serial_dict.pop("mdb_mace_eval_forces")
+
+        # struct = aiida_serialized_ase_dict_to_atoms(struct_serial_dict)
+        result_list.append(struct_serial_dict)
+
+    return_list = List([val for val in result_list])
     return return_list
 
 

--- a/src/MatDBForge/active_learning/mace_code/mace_get_descriptors.py
+++ b/src/MatDBForge/active_learning/mace_code/mace_get_descriptors.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Script to get the MACE descriptors from a structure database."""
+
+import pickle
+
+import numpy as np
+from ase.io import read as ase_read
+from mace.calculators import MACECalculator
+
+
+def generate_descriptors(model_path: str, database):
+    calculator = MACECalculator(
+        model_paths=model_path, device="cuda", default_dtype="float32"
+    )
+    descriptor_dict = {}
+    descriptor_list = []
+    for struct in database:
+        descriptor_dict[struct.info["aiida_uuid"]] = []
+
+    for struct in database:
+        curr_struct_descriptors = calculator.get_descriptors(struct)
+        descriptor_list.append(curr_struct_descriptors)
+        descriptor_dict[struct.info["aiida_uuid"]].append(curr_struct_descriptors)
+
+    descriptor_arr = np.vstack(descriptor_list)
+    return descriptor_dict, descriptor_arr
+
+
+if __name__ == "__main__":
+    # As this code will be run as a script, 
+    # we can keep these variables as constant.
+    DATABASE_PATH = "current_db.xyz"
+    MODEL_PATH = "current_model_mace.model"
+
+    # Read database using ase into an Atoms object
+    database = ase_read(DATABASE_PATH, format="extxyz", index=":")
+
+    # Generate descriptors using MACE
+    descriptor_dict, descriptor_arr = generate_descriptors(MODEL_PATH, database)
+
+    # Minimum and maximum values for each of the descriptors from MACE
+    min_val = np.min(descriptor_arr, axis=0)
+    max_val = np.max(descriptor_arr, axis=0)
+
+    # Storing arrays into a numpy file to be later gathered by the workchain
+    np.save(file="curr_it_db_max", arr=max_val)
+    np.save(file="curr_it_db_min", arr=min_val)
+
+    # No way to store all of the descriptors in a single array,
+    # as the n_atom dimension will change according to the structure
+    # This pickle object will contain a list of length n_struct,
+    # that will have n_at lists inside, each containing model_size
+    # lists of descriptor values.
+    with open("curr_it_db_descriptors.pkl", "wb") as f:
+        pickle.dump(descriptor_dict, f)

--- a/src/MatDBForge/active_learning/mace_code/run_mdb_mace_get_descriptors.sh
+++ b/src/MatDBForge/active_learning/mace_code/run_mdb_mace_get_descriptors.sh
@@ -1,0 +1,1 @@
+python ./mace_get_descriptors.py

--- a/src/MatDBForge/active_learning/mace_tools_aiida.py
+++ b/src/MatDBForge/active_learning/mace_tools_aiida.py
@@ -1,4 +1,5 @@
 import json
+import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -10,16 +11,12 @@ from aiida.orm import (
     Float,
     SinglefileData,
     Str,
-    JsonableData,
     StructureData,
     to_aiida_type,
 )
 from aiida.parsers.parser import Parser
-from ase.io import write as ase_write
 from ase.io import read as ase_read
-import io
-import tempfile
-
+from ase.io import write as ase_write
 from MatDBForge.active_learning import active_learning_utils as mdb_al_ut
 
 
@@ -211,12 +208,10 @@ class GetMACEDescriptorsCalculation(CalcJob):
         )
         spec.input(
             "mace_train_file_path",
-            # valid_type=Str,
             help=(
                 "Path to the file containing the structures to be used for training, "
                 "in the extxyz format."
             ),
-            # non_db=True,
             serializer=to_aiida_type,
         )
 
@@ -325,6 +320,9 @@ class EvaluateMACEConfigsCalculation(CalcJob):
             valid_type=ArrayData,
             help="Array of values for the force prediction.",
         )
+        spec.exit_code(
+            420, "ERROR_INVALID_OUTPUT", "training calculation could not run"
+        )
 
     def prepare_for_submission(self, folder):
         """Write the input files that are required for the code to run.
@@ -333,7 +331,6 @@ class EvaluateMACEConfigsCalculation(CalcJob):
         :return: `~aiida.common.datastructures.CalcInfo` instance
         """
         # Parsing mace settings dict
-        # TODO: Add a way of checking if validation_file was given.
         params_list = []
         params_list.append("--model=current_mace_model.model")
         params_list.append("--configs=current_configuration.xyz")
@@ -409,6 +406,10 @@ class EvaluateMACEConfigsCalculationParser(Parser):
                 result_structure = ase_read(child_file, format="extxyz")
                 result_dict = mdb_al_ut.serialize_ase(result_structure)
                 forces_dict = np.vstack(result_dict["mdb_mace_eval_forces"])
+
+        # Return failed code if output files not found
+        if not result_structure or not result_dict:
+            return self.exit_codes.ERROR_INVALID_OUTPUT
 
         # Return CalcJob outputs
         self.out("configuration_result_dict", Dict(result_dict))

--- a/src/MatDBForge/active_learning/mace_tools_aiida.py
+++ b/src/MatDBForge/active_learning/mace_tools_aiida.py
@@ -1,0 +1,416 @@
+import json
+from pathlib import Path
+
+import numpy as np
+from aiida.common.datastructures import CalcInfo, CodeInfo
+from aiida.engine import CalcJob
+from aiida.orm import (
+    ArrayData,
+    Dict,
+    Float,
+    SinglefileData,
+    Str,
+    JsonableData,
+    StructureData,
+    to_aiida_type,
+)
+from aiida.parsers.parser import Parser
+from ase.io import write as ase_write
+from ase.io import read as ase_read
+import io
+import tempfile
+
+from MatDBForge.active_learning import active_learning_utils as mdb_al_ut
+
+
+class TrainMACEModelCalculationParser(Parser):
+    def parse(self, **kwargs):
+        """Parse the retrieved files of the calculation job."""
+        # str that represents the absolute filepath to the temporary folder
+        retrieved_temporary_folder: Path = Path(kwargs["retrieved_temporary_folder"])
+
+        model_file = None
+        rmse_e = None
+        rmse_f = None
+
+        for child_file in retrieved_temporary_folder.iterdir():
+            # create singlefile data for the model
+            if "swa.model" in child_file.name:
+                model_file = SinglefileData(file=child_file)
+
+            if "train.txt" in child_file.name:
+                # TODO: gather rmse_e, rmse_f
+                with open(child_file) as f:
+                    for line in f:
+                        line_dict = json.loads(line)
+                        if "rmse_e" in line_dict:
+                            last_dict = line_dict
+
+                rmse_e = float(last_dict["rmse_e_per_atom"]) * 1000  # meV / atom
+                rmse_f = float(last_dict["rmse_f"]) * 1000  # meV / A
+
+        # Return failed code
+        if not rmse_e or not rmse_f or not model_file:
+            return self.exit_codes.ERROR_INVALID_OUTPUT
+
+        # Return CalcJob outputs
+        self.out("model_file", model_file)
+        self.out("m_rmse_e", Float(rmse_e))
+        self.out("m_rmse_f", Float(rmse_f))
+
+
+class TrainMACEModelCalculation(CalcJob):
+    """Implementation of CalcJob to perform a MACE training using a settings dir."""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "mace_settings_dict",
+            valid_type=Dict,
+            help="Dictionary containing MACE training settings.",
+        )
+        spec.input(
+            "mace_train_file_path",
+            valid_type=Str,
+            help=(
+                "Path to the file containing the structures to be used for training, "
+                "in the extxyz format."
+            ),
+            # non_db=True,
+            serializer=to_aiida_type,
+        )
+        spec.input(
+            "test_file",
+            valid_type=SinglefileData,
+            help=(
+                "File containing the structures to be used for training, "
+                "in the extxyz format."
+            ),
+            required=False,
+            default=None,
+        )
+
+        spec.input(
+            "model_name",
+            valid_type=Str,
+            help=("Name given to the model."),
+            serializer=to_aiida_type,
+        )
+
+        spec.output(
+            "model_file",
+            valid_type=SinglefileData,
+            help="Path of the trained MACE model.",
+        )
+        spec.output(
+            "m_rmse_e",
+            valid_type=Float,
+            help="Validation RMSE for the energy, in meV / atom.",
+        )
+        spec.output(
+            "m_rmse_f",
+            valid_type=Float,
+            help="Validation RMSE for the forces, in meV / Å.",
+        )
+        spec.exit_code(
+            420, "ERROR_INVALID_OUTPUT", "training calculation could not run"
+        )
+
+    def prepare_for_submission(self, folder):
+        """Write the input files that are required for the code to run.
+
+        :param folder: an `~aiida.common.folders.Folder` to temporarily write files on disk
+        :return: `~aiida.common.datastructures.CalcInfo` instance
+        """
+        # Parsing mace settings dict
+        # TODO: Add a way of checking if validation_file was given.
+        params_list = []
+        for key, val in self.inputs.mace_settings_dict.items():
+            if key == "train_file":
+                val = Path(val).resolve().name
+
+            if isinstance(val, str):
+                curr_key = f"--{key}={val}"
+            elif isinstance(val, bool):
+                if val:
+                    curr_key = f"--{key}"
+            else:
+                curr_key = f"--{key}={val}"
+            params_list.append(curr_key)
+
+        # Adding random seed
+        params_list.append(f"--seed={np.random.randint(1, 100000000)}")
+
+        # Copying database to temporary folder
+        final_db_path = self.inputs.mace_train_file_path.value
+        folder.insert_path(
+            src=final_db_path,
+            dest_name=self.inputs.mace_settings_dict["train_file"],
+        )
+
+        codeinfo = CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.stdout_name = self.options.output_filename
+        codeinfo.cmdline_params = params_list
+
+        calcinfo = CalcInfo()
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.local_copy_list = []
+        calcinfo.provenance_exclude_list = [
+            self.inputs.mace_settings_dict["train_file"]
+        ]
+        calcinfo.remote_copy_list = []
+
+        # Gathering files. They won't be added to the repository,
+        # and instead kept into a temporary folder.
+        # They can later be processed during the parse function
+        # by accessing the temporary folder.
+        calcinfo.retrieve_temporary_list = [
+            self.metadata.options.output_filename,
+            "./*.model",
+            "./results/*",
+        ]
+
+        return calcinfo
+
+
+class GetMACEDescriptorsCalculationParser(Parser):
+    def parse(self, **kwargs):
+        """Parse the retrieved files of the calculation job."""
+        # str that represents the absolute filepath to the temporary folder
+        retrieved_temporary_folder: Path = Path(kwargs["retrieved_temporary_folder"])
+
+        for child_file in retrieved_temporary_folder.iterdir():
+            # create singlefile data for the descriptors
+            if "curr_it_db_descriptors.pkl" in child_file.name:
+                descriptor_arr_file = SinglefileData(file=child_file)
+
+            if "curr_it_db_max.npy" in child_file.name:
+                descr_max_arr = ArrayData(np.load(child_file))
+
+            if "curr_it_db_min.npy" in child_file.name:
+                descr_min_arr = ArrayData(np.load(child_file))
+
+        # Return CalcJob outputs
+        self.out("descriptors_file", descriptor_arr_file)
+        self.out("descriptors_max_array", descr_max_arr)
+        self.out("descriptors_min_array", descr_min_arr)
+
+
+class GetMACEDescriptorsCalculation(CalcJob):
+    """Implementation of CalcJob to perform a MACE training using a settings dir."""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "model_file",
+            valid_type=SinglefileData,
+            help="Path of the trained MACE model.",
+        )
+        spec.input(
+            "mace_train_file_path",
+            # valid_type=Str,
+            help=(
+                "Path to the file containing the structures to be used for training, "
+                "in the extxyz format."
+            ),
+            # non_db=True,
+            serializer=to_aiida_type,
+        )
+
+        spec.output(
+            "descriptors_file",
+            valid_type=SinglefileData,
+            help="Path of the file containing the MACE descriptors array.",
+        )
+        spec.output(
+            "descriptors_max_array",
+            valid_type=ArrayData,
+            help="Array containing the maximum values for the MACE descriptors, "
+            "shaped according to the model size.",
+        )
+        spec.output(
+            "descriptors_min_array",
+            valid_type=ArrayData,
+            help="Array containing the minimum values for the MACE descriptors, "
+            "shaped according to the model size.",
+        )
+
+    def prepare_for_submission(self, folder):
+        """Write the input files that are required for the code to run.
+
+        :param folder: an `~aiida.common.folders.Folder` to temporarily write files on disk
+        :return: `~aiida.common.datastructures.CalcInfo` instance
+        """
+        # Copying database to temporary folder
+        if isinstance(self.inputs.mace_train_file_path, Str):
+            final_db_path = self.inputs.mace_train_file_path.value
+            folder.insert_path(
+                src=Path(final_db_path),
+                dest_name="current_db.xyz",
+            )
+        elif isinstance(self.inputs.mace_train_file_path, SinglefileData):
+            with self.inputs.mace_train_file_path.as_path() as model_path:
+                folder.insert_path(
+                    src=model_path,
+                    dest_name="current_db.xyz",
+                )
+
+        # Copying model to temporary folder
+        model_file = self.inputs.model_file
+
+        with model_file.as_path() as model_path:
+            folder.insert_path(
+                src=model_path,
+                dest_name="current_model_mace.model",
+            )
+
+        codeinfo = CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+
+        calcinfo = CalcInfo()
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.local_copy_list = []
+        calcinfo.provenance_exclude_list = []
+        calcinfo.remote_copy_list = []
+
+        # Gathering files. They won't be added to the repository,
+        # and instead kept into a temporary folder.
+        # They can later be processed during the parse function
+        # by accessing the temporary folder.
+        calcinfo.retrieve_temporary_list = [
+            "*.npy",
+            "*.pkl",
+        ]
+
+        return calcinfo
+
+
+class EvaluateMACEConfigsCalculation(CalcJob):
+    """CalcJob to evaluate E and F of structures using a MACE model."""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "mace_settings_dict",
+            valid_type=Dict,
+            help="Dictionary containing MACE settings.",
+            serializer=to_aiida_type,
+        )
+        spec.input(
+            "model_file",
+            valid_type=SinglefileData,
+            help="Path of the trained MACE model.",
+        )
+        spec.input(
+            "configuration_to_evaluate",
+            valid_type=StructureData,
+            help="Path of the trained MACE model.",
+        )
+        spec.output(
+            "configuration_result_dict",
+            valid_type=Dict,
+            help="Dict representation of the predicted configuration using MACE.",
+        )
+        spec.output(
+            "energy_result",
+            valid_type=Float,
+            help="Value for the energy prediction.",
+        )
+        spec.output(
+            "forces_result",
+            valid_type=ArrayData,
+            help="Array of values for the force prediction.",
+        )
+
+    def prepare_for_submission(self, folder):
+        """Write the input files that are required for the code to run.
+
+        :param folder: an `~aiida.common.folders.Folder` to temporarily write files on disk
+        :return: `~aiida.common.datastructures.CalcInfo` instance
+        """
+        # Parsing mace settings dict
+        # TODO: Add a way of checking if validation_file was given.
+        params_list = []
+        params_list.append("--model=current_mace_model.model")
+        params_list.append("--configs=current_configuration.xyz")
+        params_list.append("--output=results.out")
+
+        for key, val in self.inputs.mace_settings_dict.items():
+            if key == "train_file":
+                val = Path(val).resolve().name
+
+            if isinstance(val, str):
+                curr_key = f"--{key}={val}"
+            elif isinstance(val, bool):
+                if val:
+                    curr_key = f"--{key}"
+            else:
+                curr_key = f"--{key}={val}"
+            params_list.append(curr_key)
+
+        params_list.append("--info_prefix=mdb_mace_eval_")
+
+        # Copying configuration to temporary folder
+        with self.inputs.model_file.as_path() as model_path:
+            folder.insert_path(
+                src=model_path,
+                dest_name="current_mace_model.model",
+            )
+
+        curr_structure: StructureData = self.inputs.configuration_to_evaluate
+        curr_structure_ase = curr_structure.get_ase()
+        tmp_struct_file = tempfile.NamedTemporaryFile(delete=False)
+        ase_write(
+            filename=tmp_struct_file.name, images=curr_structure_ase, format="extxyz"
+        )
+
+        folder.insert_path(
+            src=tmp_struct_file.name,
+            dest_name="current_configuration.xyz",
+        )
+
+        codeinfo = CodeInfo()
+        codeinfo.code_uuid = self.inputs.code.uuid
+        codeinfo.cmdline_params = params_list
+
+        calcinfo = CalcInfo()
+        calcinfo.codes_info = [codeinfo]
+        calcinfo.local_copy_list = []
+        calcinfo.provenance_exclude_list = []
+        calcinfo.remote_copy_list = []
+
+        # Gathering files.
+        calcinfo.retrieve_list = [
+            "results.out",
+        ]
+
+        # They won't be added to the repository,
+        # and instead kept into a temporary folder.
+        calcinfo.retrieve_temporary_list = [
+            "results.out",
+        ]
+
+        return calcinfo
+
+
+class EvaluateMACEConfigsCalculationParser(Parser):
+    def parse(self, **kwargs):
+        """Parse the retrieved files of the calculation job."""
+        # str that represents the absolute filepath to the temporary folder
+        retrieved_temporary_folder: Path = Path(kwargs["retrieved_temporary_folder"])
+
+        for child_file in retrieved_temporary_folder.iterdir():
+            # create singlefile data for the descriptors
+            if child_file.name == "results.out":
+                result_structure = ase_read(child_file, format="extxyz")
+                result_dict = mdb_al_ut.serialize_ase(result_structure)
+                forces_dict = np.vstack(result_dict["mdb_mace_eval_forces"])
+
+        # Return CalcJob outputs
+        self.out("configuration_result_dict", Dict(result_dict))
+        self.out("energy_result", Float(result_dict["info"]["mdb_mace_eval_energy"]))
+        self.out("forces_result", ArrayData(forces_dict))

--- a/src/MatDBForge/core/command_line.py
+++ b/src/MatDBForge/core/command_line.py
@@ -83,8 +83,12 @@ def create_active_learning_builder(toml_dict: dict):
     # Committee Evaluation Settings
     builder.active_learning.committee_eval = Dict(value=toml_dict["committee_eval"])
 
-    # DFT Settings
-    builder.active_learning.dft_settings = Dict(value=toml_dict["vasp"])
+    # DFT method selection and settings
+    builder.active_learning.dft_method = al_conf["dft_method"]
+    if al_conf["dft_method"] == "vasp":
+        builder.active_learning.dft_settings = Dict(value=toml_dict["dft"]["vasp"])
+    elif al_conf["dft_method"] == "mace":
+        builder.active_learning.dft_settings = Dict(value=toml_dict["dft"]["mace"])
 
     return builder
 

--- a/src/MatDBForge/data/input_files/active_learning_settings.toml
+++ b/src/MatDBForge/data/input_files/active_learning_settings.toml
@@ -40,8 +40,12 @@ al_keep_struct_every_n_ps = 1
 # Whether to check for extrapolation using the MACE descriptors
 check_extrapolation = true
 
+# Selection of DFT calculator.
+dft_method = "vasp" # Options: "vasp", "mace"
+
 ###############################################
 
+# Settings for MD simulations using LAMMPS
 [md]
 [md.parameters]
 # List of different temperatures (in K) to be used for the MD simulations.
@@ -138,14 +142,41 @@ device = "cuda"
 default_dtype = "float32"
 wandb = false
 
+###############################################
 
-# VASP DFT Settings
-[vasp]
+# DFT Settings
+[dft]
+
+# MACE Settings as DFT calculator. Ignored if dft_method = "vasp" 
+[dft.mace]
+mace_potential_path = "" # Path to MACE potential file
+
+# Options for MACE. Will be passed as arguments during MACE execution.
+[dft.mace.settings]
+device = "cuda"           # Options: "cpu", "cuda"
+default_dtype = "float32" # Options: "float32", "float64"
+batch_size = 64
+compute_stress = false    # Options: true, false
+
+# Scheduler options. Will be used in the builder.metadata.options.
+[dft.mace.options]
+parser_name = "mace-eval-parser"
+code_string = "mace_run_eval_gpu@tekla2-new-test"
+resources = { parallel_env = "c128m1024ib_mpi_32slots", tot_num_mpiprocs = 32 }
+max_wallclock_seconds = 117280000
+max_memory_kb = 102400000
+custom_scheduler_commands = '''#$ -l gpu=1
+#$ -l hostname="tekla2189"'''
+withmpi = false
+
+
+# Settings for VASP as DFT calculator. Ignored if dft_method = "mace" 
+[dft.vasp]
 # potential_family = "vasp-5.3-PBE"
 potential_family = "vasp-5.4-PBE-2023"
 structure_types = ['bulk', 'surface', 'cluster']
 
-[vasp.queue]
+[dft.vasp.queue]
 type = "sge"
 node_cpus = 12
 code_string = "vasp-std-5.4.4-new@tekla2"
@@ -153,7 +184,7 @@ options_resources = { parallel_env = "c12m48ib_mpi", tot_num_mpiprocs = 12 }
 multiple = 1
 custom_scheduler_commands = '#$ -l hostname="tekla2044"'
 
-[vasp.kspacing]
+[dft.vasp.kspacing]
 alpha = 0.135088484104361
 # m1 = 0.100530964914873
 beta-prime = 0.102415920507027
@@ -166,7 +197,7 @@ eta = 0.0993371597065093
 delta = 0.0994491889005363
 
 # general incar settings to be used as a template for all calculations
-[vasp.incar]
+[dft.vasp.incar]
 istart = 0
 icharg = 2
 gga = "Pe"
@@ -189,16 +220,16 @@ ncore = 4
 lelf = false
 ivdw = 11      # van der Waals
 
-[vasp.relax.incar]
+[dft.vasp.relax.incar]
 ibrion = 2
 nsw = 350
 isif = 3
 
-[vasp.surface.incar]
+[dft.vasp.surface.incar]
 ldipol = true
 idipol = 3
 
-[vasp.cluster.incar]
+[dft.vasp.cluster.incar]
 ldipol = true
 dipol = [0.5, 0.5, 0.5]
 idipol = 4

--- a/src/MatDBForge/workflows/active_learning.py
+++ b/src/MatDBForge/workflows/active_learning.py
@@ -102,6 +102,7 @@ class ActiveLearningWorkChain(WorkChain):
             serializer=to_aiida_type,
         )
         spec.input("lammps_mace", valid_type=Dict)
+        spec.input("dft_method", valid_type=Str, serializer=to_aiida_type)
         spec.input("dft_settings", valid_type=Dict)
         spec.input("committee_eval", valid_type=Dict)
         spec.input("check_extrapolation", valid_type=Bool, serializer=to_aiida_type)
@@ -1154,13 +1155,24 @@ class ActiveLearningWorkChain(WorkChain):
                 # print('dft_structures: ', dft_structures)
 
                 for calc_idx, dft_struct in enumerate(dft_structures):
-                    builder = mdb_al_ut.get_dft_calc_builder(
-                        dft_struct,
-                        row,
-                        calc_idx,
-                        self.inputs.train_seed_group.value,
-                        dft_settings=self.inputs.dft_settings.get_dict(),
-                    )
+                    if self.inputs.dft_method == "vasp":
+
+                        builder = mdb_al_ut.get_dft_calc_builder_vasp(
+                            dft_struct,
+                            row,
+                            calc_idx,
+                            self.inputs.train_seed_group.value,
+                            dft_settings=self.inputs.dft_settings.get_dict(),
+                        )
+
+                    elif self.inputs.dft_method == "mace":
+                            builder = mdb_al_ut.get_dft_calc_builder_mace(
+                            dft_struct,
+                            row,
+                            calc_idx,
+                            self.inputs.train_seed_group.value,
+                            dft_settings=self.inputs.dft_settings.get_dict(),
+                        )
 
                     # Submitting current calculation
                     future = self.submit(builder)
@@ -1204,17 +1216,28 @@ class ActiveLearningWorkChain(WorkChain):
         MACE models, and this check also outputted to the workchain using the
         namespace `stop_md_seed_no_disagreement`.
         """
-        try:
-            dft_calcs = len(self.ctx.dft_struct_seed_calcs)
-            self.report(f"Gathered {dft_calcs} DFT calculations.")
+        if self.inputs.dft_method == "vasp":
+            try:
+                dft_calcs = len(self.ctx.dft_struct_seed_calcs)
+                self.report(f"Gathered {dft_calcs} VASP DFT calculations.")
 
-            return_list = mdb_al_ut.gather_dft_calcs(
-                [node.uuid for node in self.ctx.dft_struct_seed_calcs]
-            )
+                return_list = mdb_al_ut.gather_dft_calcs_vasp(
+                    [node.uuid for node in self.ctx.dft_struct_seed_calcs]
+                )
 
-        except AttributeError:
-            # self.ctx.dft_struct_seed_calcs = []
-            return_list = List([])
+            except AttributeError:
+                return_list = List([])
+
+        elif self.inputs.dft_method == "mace":
+            try:
+                dft_calcs = len(self.ctx.dft_struct_seed_calcs)
+                self.report(f"Gathered {dft_calcs} MACE DFT calculations.")
+
+                return_list = mdb_al_ut.gather_dft_calcs_mace(
+                    [node.uuid for node in self.ctx.dft_struct_seed_calcs]
+                )
+            except AttributeError:
+                return_list = List([])
 
         self.out("dft_calcs", return_list)  # list[dict]
         self.out(

--- a/src/MatDBForge/workflows/aiida_utils.py
+++ b/src/MatDBForge/workflows/aiida_utils.py
@@ -430,17 +430,7 @@ def submit_aiida_vasp_calculation(
         builder["relax"]["perform"] = Bool(True)
 
     if dry_run:
-        # print('dir builder:\n',dir(builder))
-        # print(builder.metadata)
-        # print(type(builder.metadata))
-        # print(dir(builder.metadata))
-        # print(builder.metadata._port_namespace)
-        # print("\nmetadata valid fields: ",builder.metadata._valid_fields)
-        # # print("\nsettings valid fields: ",builder.settings._valid_fields)
-        # print("\nparameters valid fields: ",builder.parameters._valid_fields)
-        # print("\noptions valid fields: ",builder.options._valid_fields)
-
-        # Generate a fake node and return it?
+        # TODO: Generate a fake node and return it
         mdb_ut.custom_print("Dry run: nothing generated.", "debug")
 
     if return_builder:


### PR DESCRIPTION
Closes #17 

## Introduce MACE as a DFT calculator option in active learning 
This adds flexibility to the active learning framework by allowing the use of either VASP or MACE for DFT calculations, providing a faster way of obtaining electronic structure information.

   - Implement `EvaluateMACEConfigsCalculation` class to handle energy and force calculations using MACE models.
   - Add configuration handling in the active learning workflow to support both VASP and MACE DFT methods.
   - Update TOML settings to include MACE configuration options alongside existing VASP settings.
   - Refactor related functions in the workflow to conditionally build DFT calculation setups based on the selected DFT method.
   - Include a new parser `EvaluateMACEConfigsCalculationParser` to handle outputs from MACE-based DFT calculations.
   - Adjust active learning settings in `active_learning_settings.toml` to allow dynamic selection between VASP and MACE as DFT calculators.

