### PR TITLE
Use SinglefileData for MD structures and filter outliers

### DIFF
--- a/src/MatDBForge/__init__.py
+++ b/src/MatDBForge/__init__.py
@@ -3,4 +3,4 @@ import pathlib as pl
 # Root of package
 MDB_ROOT_DIR = (pl.Path(__file__).parent).resolve()
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"

--- a/src/MatDBForge/active_learning/active_learning_utils.py
+++ b/src/MatDBForge/active_learning/active_learning_utils.py
@@ -126,17 +126,19 @@ def select_dft_structures(struct_arr, frame_interval):
 
 def select_md_frames_to_keep(
     frame_interval: int,
-    total_n_frames: int,
+    # total_n_frames: int,
     md_tstep_duration_ps: float,
     traj,
     steps_E_F_arr: np.array,
     forces: np.array,
 ):
     # Get total MD time in picoseconds
-    total_duration_ps = total_n_frames * md_tstep_duration_ps
+    total_duration_ps = len(traj) * md_tstep_duration_ps
 
-    # Get total number of frames in that time
-    total_num_frames = m.ceil(total_duration_ps * frame_interval)
+    # Get total number of frames in that time.
+    # Frame interval represents every how many ps of MD simulation
+    # save a frame.
+    total_num_frames = m.ceil(total_duration_ps * 1 / frame_interval)
 
     # Choose the number of frames evenly and create a mask for the arrays
     mask = np.linspace(0, len(traj) - 1, total_num_frames, dtype=int)
@@ -344,7 +346,7 @@ def get_final_db_path(result_dir_path, final_db_name, node):
     return final_db_path, curr_run_dir
 
 
-def get_results_dir_path(result_dir_path, node):
+def get_results_dir_path(result_dir_path, node, check_temp_dir=True):
     result_dir_path = Path(result_dir_path)
 
     caller_uuid = process_call_root(node) if not isinstance(node, str) else node
@@ -352,6 +354,8 @@ def get_results_dir_path(result_dir_path, node):
 
     if not curr_run_dir.exists():
         curr_run_dir.mkdir()
+    if check_temp_dir and not (curr_run_dir / "run_tmp_data").exists():
+        (curr_run_dir / "run_tmp_data").mkdir()
 
     return curr_run_dir
 
@@ -446,11 +450,12 @@ def update_mace_train_settings_dict(
     return Dict(settings_dict)
 
 
+# rmse_e and rmse_f are used by the dashboard
 @calcfunction
 def create_mace_lammps_model(model_file, rmse_e, rmse_f):
     with model_file.as_path() as model_path:
         # Loading model
-        model = torch.load(model_path)
+        model = torch.load(model_path, map_location=torch.device("cpu"))
         model = model.double().to("cpu")
         lammps_model = LAMMPS_MACE(model)
         lammps_model_compiled = jit.compile(lammps_model)
@@ -595,28 +600,32 @@ def gather_dft_calcs_vasp(dft_calc_list: list) -> List:
 
 
 @calcfunction
-def gather_dft_calcs_mace(dft_calc_list: list) -> List:
+def gather_dft_calcs_mace(dft_calc_list: list, results_dir: str) -> Str:
     """Collect and preprocess MACE DFT calculation results for active learning input."""
     result_list = []
 
     # Adding structures to the initial DB
     for finished_dft_calc in dft_calc_list:
         calc_node = load_node(finished_dft_calc)
+        print("\ncalc_node: ", calc_node)
 
         try:
-            # Gathering the calculation data as a list of ASE Atoms dicts.
-            # This object won't collect automatically all of the extra information
-            # such as forces or energies, and must be collected using methods
-            # from ase.calc.
-            struct_serial_dict_list = calc_node.outputs.configuration_result_list
+            # Gathering the calculation data from a extxyz stored as a SinglefileData.
+            struct_file: SinglefileData = calc_node.outputs.configuration_result_file
+            with struct_file.as_path() as struct_file_path:
+                result_structures = ase_read(
+                    struct_file_path, format="extxyz", index=":"
+                )
 
+        # If the calculation fails for any reason, skip it.
         except Exception:
-            # If the calculation fails for any reason, skip it.
             continue
 
-        for struct_serial_dict in struct_serial_dict_list:
+        curr_struct_res = []
+        for structure in result_structures:
             # Gathering extra DFT calculation information from calculation
             # and its extras
+            # print('structure.info: ', structure.info)
             calc_info_dict = {
                 "struct_name": calc_node.label + "_aiida-uuid_" + calc_node.uuid,
                 "aiida_uuid": calc_node.extras["mdb_calc_uuid"],
@@ -624,23 +633,74 @@ def gather_dft_calcs_mace(dft_calc_list: list) -> List:
             }
 
             for key, val in calc_info_dict.items():
-                struct_serial_dict["info"][key] = val
+                structure.info[key] = val
 
             # Renaming energy key
-            struct_serial_dict["info"]["energy"] = struct_serial_dict["info"].pop(
-                "mdb_mace_eval_energy"
-            )
+            structure.info["energy"] = structure.info.pop("mdb_mace_eval_energy")
 
             # Renaming forces dict
-            struct_serial_dict["forces"] = struct_serial_dict.pop(
-                "mdb_mace_eval_forces"
-            )
+            structure.arrays["forces"] = structure.arrays.pop("mdb_mace_eval_forces")
 
-            # struct = aiida_serialized_ase_dict_to_atoms(struct_serial_dict)
-            result_list.append(struct_serial_dict)
+            # result_list.append(structure)
+            curr_struct_res.append(structure)
 
-    return_list = List([val for val in result_list])
-    return return_list
+        energy_list = [structure.info["energy"] for structure in curr_struct_res]
+        forces_list = [
+            np.max(np.max(np.abs(structure.arrays["forces"]), axis=0))
+            for structure in curr_struct_res
+        ]
+
+        # Checking for outliers using the IQR Method
+        # This involves calculating the first (Q1) and third quartiles (Q3)
+        # and the interquartile range (IQR = Q3 - Q1).
+        # Outliers are typically defined as values that are less
+        # than Q1 - 1.5IQR or greater than Q3 + 1.5IQR.
+        filtered_e_data: np.ndarray = iqr_outlier_check(energy_list)
+        filtered_f_data: np.ndarray = iqr_outlier_check(forces_list)
+
+        # Create boolean masks for non-NaN positions
+        e_mask = ~np.isnan(filtered_e_data)
+        f_mask = ~np.isnan(filtered_f_data)
+
+        # Combine the masks for E and F
+        filtered_data = e_mask & f_mask
+
+        # Some calculations that reported high E and F thoughout all
+        # steps, might not be caught by the filters
+        # Therefore, if the max after filtering is still a very
+        # high energy value, we ignore this calculation.
+        abs_max = np.nanmax(np.abs(filtered_e_data))
+        if abs_max <= 5e4:
+            for idx, struct in enumerate(filtered_data):
+                if struct:
+                    result_list.append(curr_struct_res[idx])
+
+    # Write the results to a temporary file in the calculation directory
+    results_dir = (
+        Path(results_dir.value) if isinstance(results_dir, Str) else results_dir
+    )
+    results_file_path = results_dir / "run_tmp_data" / "gathered_dft_calcs.xyz"
+    ase_write(filename=results_file_path, images=result_list)
+
+    # Return the path to the temporary file
+    return Str(str(results_file_path))
+
+
+def iqr_outlier_check(res_list) -> np.ndarray:
+    q1 = np.percentile(res_list, 30)
+    q2 = np.percentile(res_list, 70)
+    iqr = q2 - q1
+
+    # Define outlier thresholds
+    lower_bound = q1 - 1.5 * iqr
+    upper_bound = q2 + 1.5 * iqr
+
+    # Identify and remove outliers
+    filtered_data = np.array(
+        [x if lower_bound <= x <= upper_bound else np.nan for x in res_list]
+    )
+
+    return filtered_data
 
 
 def vasprun_add_info_dict(vasprun_dict, calc_info_dict):
@@ -721,7 +781,7 @@ def remove_structs_from_seed_gen_db(seed_gen_path: Str, delete_indices: list) ->
 
 
 @calcfunction
-def check_md_seed_agreement(return_list: list) -> Bool:
+def check_md_seed_agreement(return_list_path: str) -> Bool:
     """
     Check if all predictions agree for current seed.
 
@@ -738,7 +798,7 @@ def check_md_seed_agreement(return_list: list) -> Bool:
         on the current AL iteration. False if there is no agreement on
         on all structures.
     """
-    if len(return_list) > 0:
+    if len(return_list_path.value) > 0:
         return Bool(False)
     else:
         return Bool(True)

--- a/src/MatDBForge/active_learning/active_learning_utils.py
+++ b/src/MatDBForge/active_learning/active_learning_utils.py
@@ -334,11 +334,7 @@ def generate_model_name():
 
 def get_final_db_path(result_dir_path, final_db_name, node):
     result_dir_path = Path(result_dir_path)
-    if not isinstance(node, str):
-        caller_uuid = process_call_root(node)
-    else:
-        caller_uuid = node
-
+    caller_uuid = process_call_root(node) if not isinstance(node, str) else node
     curr_run_dir: Path = result_dir_path / f"run_{caller_uuid}"
 
     if not curr_run_dir.exists():
@@ -346,6 +342,18 @@ def get_final_db_path(result_dir_path, final_db_name, node):
 
     final_db_path = curr_run_dir / f"{final_db_name}.xyz"
     return final_db_path, curr_run_dir
+
+
+def get_results_dir_path(result_dir_path, node):
+    result_dir_path = Path(result_dir_path)
+
+    caller_uuid = process_call_root(node) if not isinstance(node, str) else node
+    curr_run_dir: Path = result_dir_path / f"run_{caller_uuid}"
+
+    if not curr_run_dir.exists():
+        curr_run_dir.mkdir()
+
+    return curr_run_dir
 
 
 def process_call_root(process):

--- a/src/MatDBForge/active_learning/dashboard/static/style.css
+++ b/src/MatDBForge/active_learning/dashboard/static/style.css
@@ -491,3 +491,67 @@ body {
     background-color: var(--button-hover-color);
     color: var(--button-hover-bg-color);
 }
+
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+    margin: 0.5%;
+  }
+  
+  /* Hide default HTML checkbox */
+  .switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  
+  /* The slider */
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--text-color);
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: var(--bg-color);
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  input:checked + .slider {
+    background-color: var(--button-bg-color);
+  }
+  
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+  
+  input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+  }
+  
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+  }
+  
+  .slider.round:before {
+    border-radius: 50%;
+  }

--- a/src/MatDBForge/active_learning/dashboard/templates/training_dashboard.html
+++ b/src/MatDBForge/active_learning/dashboard/templates/training_dashboard.html
@@ -12,8 +12,13 @@
 <body>
     <div class="header">
         <h1 class="title">Active Learning Loop</h1>
-        <button id="theme-switch-light" class="theme-switch" onclick="setTheme('light')"></button>
-        <button id="theme-switch-dark" class="theme-switch" onclick="setTheme('dark')"></button>
+        <!-- Rounded switch with the string "T" on the button-->
+        <label class="switch">
+            <input type="checkbox" onclick="changeTheme()">
+            <span class="slider round"></span>
+        </label>
+        <!-- <button id="theme-switch-light" class="theme-switch" onclick="setTheme('light')"></button> -->
+        <!-- <button id="theme-switch-dark" class="theme-switch" onclick="setTheme('dark')"></button> -->
         <img src="{{ url_for('static', filename='logo_dark.png') }}" class="logo-left" alt="Logo">
     </div>
     <div class="top-box">
@@ -70,9 +75,15 @@
         }
 
         const setTheme = (theme) => { document.documentElement.className = theme; localStorage.setItem('theme', theme); }
-        const getTheme = () => { const theme = localStorage.getItem('theme'); theme && setTheme(theme);}
+        const getTheme = () => { const theme = localStorage.getItem('theme'); theme && setTheme(theme); }
         getTheme();
 
+        // function to change the current theme to the opposite one
+        function changeTheme() {
+            var currentTheme = localStorage.getItem('theme')
+            var newTheme = currentTheme === "light" ? "dark" : "light";
+            setTheme(newTheme);
+        }
 
     </script>
 </body>

--- a/src/MatDBForge/active_learning/dashboard/templates/training_dashboard.html
+++ b/src/MatDBForge/active_learning/dashboard/templates/training_dashboard.html
@@ -17,8 +17,6 @@
             <input type="checkbox" onclick="changeTheme()">
             <span class="slider round"></span>
         </label>
-        <!-- <button id="theme-switch-light" class="theme-switch" onclick="setTheme('light')"></button> -->
-        <!-- <button id="theme-switch-dark" class="theme-switch" onclick="setTheme('dark')"></button> -->
         <img src="{{ url_for('static', filename='logo_dark.png') }}" class="logo-left" alt="Logo">
     </div>
     <div class="top-box">
@@ -38,7 +36,7 @@
         </div>
         <div class="top-box right-box">
             <div class="top-box-left-headers">
-                <h3 class="title-upper">Current iteration performance</h3>
+                <h3 class="title-upper">Performance - Iteration {{ curr_iter }}</h3>
                 <p id="model-score-text" class="top-text">{{ model_stats }}</p>
             </div>
         </div>

--- a/src/MatDBForge/active_learning/dashboard/training_dashboard_flask.py
+++ b/src/MatDBForge/active_learning/dashboard/training_dashboard_flask.py
@@ -46,17 +46,16 @@ def get_iteration_info(node):
     class_name = "workchain-progbar"
     iter_text = "1 / ?"
 
-    print('node.is_finished: ', node.is_finished)
     if node.is_finished:
         # Filling up and restyling the progress bar.
         curr_iter = max_iters
         class_name = "workchain-progbar-done"
         iter_text = f"{curr_iter} / {max_iters}"
-        print('iter_text: ', iter_text)
+        print("iter_text: ", iter_text)
     elif node.is_excepted or node.is_failed:
         curr_iter = max_iters
         class_name = "workchain-progbar-error"
-        iter_text = f"ERROR"
+        iter_text = "ERROR"
     else:
         children = [
             child
@@ -108,7 +107,6 @@ def get_report(node):
 
     styled_report = []
     for line_idx, line in enumerate(report_lines):
-
         # Catch error strings until the next aiida report
         if "|on_except]:" in line:
             report_part = []
@@ -192,7 +190,6 @@ def run_training_dashboard(workchain_node_id, refresh_interval=60, port=8000):
             curr_iter,
             subprocess_list,
         ) = gather_information(workchain_node_id)
-        print('\n\n\n@@@progbar_class_name: ', progbar_class_name)
         return render_template(
             "training_dashboard.html",
             refresh_interval=refresh_interval,

--- a/src/MatDBForge/active_learning/dashboard/training_dashboard_flask.py
+++ b/src/MatDBForge/active_learning/dashboard/training_dashboard_flask.py
@@ -7,7 +7,7 @@ from flask import Flask, render_template
 
 
 def gather_information(workchain_node_id):
-    node = orm.load_node(workchain_node_id)
+    node: orm.WorkChainNode = orm.load_node(workchain_node_id)
     children = node.called_descendants
 
     model_stats = get_model_stats(children)
@@ -30,9 +30,12 @@ def get_model_stats(children):
     has_model = False
     for child in children:
         if child.process_label == "create_mace_lammps_model":
-            has_model = True
-            rmse_e = child.inputs.rmse_e.value
-            rmse_f = child.inputs.rmse_f.value
+            try:
+                rmse_e = child.inputs.rmse_e.value
+                rmse_f = child.inputs.rmse_f.value
+                has_model = True
+            except Exception:
+                pass
 
     if has_model:
         model_stats = f"RMSE E: {rmse_e:.2f} meV/at - RMSE F: {rmse_f:.2f} meV/at"
@@ -51,7 +54,6 @@ def get_iteration_info(node):
         curr_iter = max_iters
         class_name = "workchain-progbar-done"
         iter_text = f"{curr_iter} / {max_iters}"
-        print("iter_text: ", iter_text)
     elif node.is_excepted or node.is_failed:
         curr_iter = max_iters
         class_name = "workchain-progbar-error"

--- a/src/MatDBForge/active_learning/mace_tools_aiida.py
+++ b/src/MatDBForge/active_learning/mace_tools_aiida.py
@@ -87,6 +87,7 @@ class TrainMACEModelCalculation(CalcJob):
                 "in the extxyz format."
             ),
             required=False,
+            non_db=True,
             default=None,
         )
 
@@ -206,6 +207,7 @@ class GetMACEDescriptorsCalculation(CalcJob):
             "model_file",
             valid_type=SinglefileData,
             help="Path of the trained MACE model.",
+            non_db=True
         )
         spec.input(
             "mace_train_file_path",
@@ -283,7 +285,7 @@ class GetMACEDescriptorsCalculation(CalcJob):
 
         return calcinfo
 
-
+# entry-point: mace-eval
 class EvaluateMACEConfigsCalculation(CalcJob):
     """CalcJob to evaluate E and F of structures using a MACE model."""
 
@@ -382,7 +384,6 @@ class EvaluateMACEConfigsCalculation(CalcJob):
         ]
 
         return calcinfo
-
 
 class EvaluateMACEConfigsCalculationParser(Parser):
     def parse(self, **kwargs):
@@ -525,6 +526,7 @@ class CheckMACECommitteeResultsCalculation(CalcJob):
             "commitee_models",
             dynamic=True,
             valid_type=SinglefileData,
+            non_db=True,
         )
 
         spec.input(
@@ -537,6 +539,7 @@ class CheckMACECommitteeResultsCalculation(CalcJob):
         spec.input(
             "configurations_to_evaluate",
             valid_type=SinglefileData,
+            # non_db=True,
             help="Path to the configurations to evaluate in extxyz format.",
         )
         # spec.output(

--- a/src/MatDBForge/active_learning/mace_tools_aiida.py
+++ b/src/MatDBForge/active_learning/mace_tools_aiida.py
@@ -11,6 +11,7 @@ from aiida.orm import (
     ArrayData,
     Dict,
     Float,
+    Int,
     List,
     SinglefileData,
     Str,
@@ -207,7 +208,7 @@ class GetMACEDescriptorsCalculation(CalcJob):
             "model_file",
             valid_type=SinglefileData,
             help="Path of the trained MACE model.",
-            non_db=True
+            non_db=True,
         )
         spec.input(
             "mace_train_file_path",
@@ -285,6 +286,7 @@ class GetMACEDescriptorsCalculation(CalcJob):
 
         return calcinfo
 
+
 # entry-point: mace-eval
 class EvaluateMACEConfigsCalculation(CalcJob):
     """CalcJob to evaluate E and F of structures using a MACE model."""
@@ -309,9 +311,10 @@ class EvaluateMACEConfigsCalculation(CalcJob):
             help="Path to the configurations to evaluate in extxyz format.",
         )
         spec.output(
-            "configuration_result_list",
-            valid_type=List,
-            help="List of dicts representation of the predicted configuration using MACE.",
+            "configuration_result_file",
+            valid_type=SinglefileData,
+            # help="List of dicts representation of the predicted configuration using MACE.",
+            help="File containing all configurations evaluated using MACE in the extxyz format.",
         )
         spec.output(
             "energy_result_list",
@@ -385,6 +388,7 @@ class EvaluateMACEConfigsCalculation(CalcJob):
 
         return calcinfo
 
+
 class EvaluateMACEConfigsCalculationParser(Parser):
     def parse(self, **kwargs):
         """Parse the retrieved files of the calculation job."""
@@ -399,6 +403,7 @@ class EvaluateMACEConfigsCalculationParser(Parser):
         for child_file in retrieved_temporary_folder.iterdir():
             # create singlefile data for the descriptors
             if child_file.name == "results.out":
+                results_path = child_file.absolute()
                 result_structures = ase_read(child_file, format="extxyz", index=":")
                 for curr_structure in result_structures:
                     result_dict = mdb_al_ut.serialize_ase(curr_structure)
@@ -419,7 +424,8 @@ class EvaluateMACEConfigsCalculationParser(Parser):
             return self.exit_codes.ERROR_INVALID_OUTPUT
 
         # Return CalcJob outputs
-        self.out("configuration_result_list", List(result_dict_list))
+        # self.out("configuration_result_list", SinglefileData("result_dict_list"))
+        self.out("configuration_result_file", SinglefileData(results_path))
         self.out("energy_result_list", List(energy_float_list))
         self.out("forces_result_list", List(forces_dict_list))
 
@@ -479,6 +485,7 @@ class RunMDCalculationGPULAMMPSMACE(LammpsRawCalculation):
         return calcinfo
 
 
+# entry-point: mace-committee-eval
 class CheckMACECommitteeResultsCalculation(CalcJob):
     """CalcJob to check the E and F of structures using a committee of MACE models."""
 
@@ -511,6 +518,8 @@ class CheckMACECommitteeResultsCalculation(CalcJob):
             Dictionary of arrays of values for the force prediction.
             The dict has the following format:
             `{"model_1": <ndarray shape n_at, 3, n_frames>, "model_2": ..."}`
+        num_threads : aiida.orm.Int
+            Number of OpenMP threads to use for the evaluation.
 
         Exit Codes
         ----------
@@ -533,6 +542,12 @@ class CheckMACECommitteeResultsCalculation(CalcJob):
             "mace_settings_dict",
             valid_type=Dict,
             help="Dictionary containing MACE settings.",
+            serializer=to_aiida_type,
+        )
+        spec.input(
+            "num_threads",
+            valid_type=Int,
+            help="Number of OpenMP threads to use for the evaluation.",
             serializer=to_aiida_type,
         )
 
@@ -575,6 +590,9 @@ class CheckMACECommitteeResultsCalculation(CalcJob):
         # Adding cli parameters to list
         prepare_cli_args_mace(params_list, self.inputs.mace_settings_dict)
         params_list.append("--info_prefix=mdb_mace_eval_")
+
+        # Adding n_threads to the list
+        params_list.append(f"--num_threads={self.inputs.num_threads.value}")
 
         # Remove duplicate entries
         params_list = list(set(params_list))

--- a/src/MatDBForge/core/command_line.py
+++ b/src/MatDBForge/core/command_line.py
@@ -274,7 +274,7 @@ def monitor_al_loop():
         "--port",
         help=("Port to use for the webapp"),
         type=int,
-        default=5000,
+        default=8000,
         metavar="port",
     )
     # Getting CLI arguments

--- a/src/MatDBForge/data/input_files/active_learning_settings.toml
+++ b/src/MatDBForge/data/input_files/active_learning_settings.toml
@@ -93,6 +93,9 @@ metadata.options.custom_scheduler_commands = '''#$ -l gpu=1
 # Increases resources necessary for training.
 committee_num_models = 4
 
+# Number of OpenMP threads to be used for MACE CPU evaluation.
+openmp_threads = 8
+
 # Settings for MACE evaluator
 [committee_eval.mace]
 device = "cuda"       # cpu, cuda

--- a/src/MatDBForge/workflows/active_learning.py
+++ b/src/MatDBForge/workflows/active_learning.py
@@ -1,6 +1,7 @@
 """Definition of an aiida workchain for MACE active learning loops using MD."""
 
 import io
+import os
 import pickle
 import re
 import shutil
@@ -148,7 +149,7 @@ class ActiveLearningWorkChain(WorkChain):
             # do not change seed until the error is decreased
             # cls.choose_next_seed,
         )
-        spec.output("dft_calcs", valid_type=List, required=False)
+        spec.output("dft_calcs_path", valid_type=Str, required=False)
         spec.output("m0_model_file", valid_type=SinglefileData)
         spec.output("stop_md_seed_no_disagreement", valid_type=Bool)
 
@@ -319,7 +320,7 @@ class ActiveLearningWorkChain(WorkChain):
                 # Convert model to LAMMPS compatible format
                 # and return it to workchain context
                 self.ctx.lammps_potential_file = mdb_al_ut.create_mace_lammps_model(
-                    model_file, self.ctx.m0_rmse_e, self.ctx.m0_rmse_f
+                    model_file, rmse_e=self.ctx.m0_rmse_e, rmse_f=self.ctx.m0_rmse_f
                 )
 
                 self.report(
@@ -679,7 +680,6 @@ class ActiveLearningWorkChain(WorkChain):
             # Get 1 frame every n picoseconds of MD simulation
             traj, steps_E_F_arr, forces = mdb_al_ut.select_md_frames_to_keep(
                 frame_interval=self.inputs.al_keep_struct_every_n_ps,
-                total_n_frames=len(traj),
                 md_tstep_duration_ps=self.inputs.md_timestep_duration_ps.value,
                 traj=traj,
                 steps_E_F_arr=steps_E_F_arr,
@@ -704,12 +704,12 @@ class ActiveLearningWorkChain(WorkChain):
         # Creating a DataFrame with all the results
         md_seed_results_df = pd.DataFrame(new_rows)
 
-        results_dir = mdb_al_ut.get_results_dir_path(
+        self.ctx.results_dir = mdb_al_ut.get_results_dir_path(
             result_dir_path=self.inputs.results_dir.value, node=self.node
         )
         # Saving the DataFrame into the result directory as a file.
         self.ctx.md_seed_results_df_path = (
-            f"{results_dir}/md_seed_results_df_step-"
+            f"{self.ctx.results_dir}/run_tmp_data/md_seed_results_df_step-"
             f"{self.inputs.al_loop_iteration.value}.pkl"
         )
         md_seed_results_df.to_pickle(path=self.ctx.md_seed_results_df_path)
@@ -735,7 +735,7 @@ class ActiveLearningWorkChain(WorkChain):
         -------
         numpy.ndarray
             A 2D numpy array where each row corresponds to a step in the workchain.
-            The columns represent step number, energy, and force,respectively.
+            The columns represent step number, energy, and force, respectively.
 
         Notes
         -----
@@ -771,10 +771,10 @@ class ActiveLearningWorkChain(WorkChain):
 
             # Getting current step results.
             # If an IndexError is raised, probably one of the results is missing,
-            # most likely because the program was stopped mid-step (above wall-time)
-            # and thus the current step must not be gathered. This allows for the AL
-            # loop to keep running even if there are MD calculations that don't run
-            # to completion.
+            # most likely because the program was stopped mid-step (maximum run time
+            # exceeded), and thus the current step must not be gathered.
+            # This allows for the AL # loop to keep running even if there are MD
+            # calculations that don't run to completion.
             try:
                 curr_step = int(split[1])
                 curr_energy = float(split[4])
@@ -1034,10 +1034,12 @@ class ActiveLearningWorkChain(WorkChain):
 
         if not commitee_dict:
             self.report(
-                "Committee dict is empty: no committee models trained."
+                "Committee dict is empty: no committee models trained. "
                 "Using main model only. Check model training step for errors."
             )
-            commitee_dict[self.ctx.best_model_name] = self.ctx.best_model_file
+            # Only alphanumeric and underscores are allowed as links
+            best_model_name_clean = self.ctx.best_model_name.replace("-", "_")
+            commitee_dict[best_model_name_clean] = self.ctx.best_model_file
 
         # Reading md seed results DataFrame
         md_seed_results_df: pd.DataFrame = pd.read_pickle(
@@ -1079,6 +1081,9 @@ class ActiveLearningWorkChain(WorkChain):
 
             # Input configurations to evaluate
             mace_builder.configurations_to_evaluate = md_xyz_file
+
+            # Input number of threads to use
+            mace_builder.num_threads = int(self.inputs.committee_eval["openmp_threads"])
 
             # Gather mace evaluation settings
             mace_builder.mace_settings_dict = Dict(self.inputs.committee_eval["mace"])
@@ -1471,6 +1476,7 @@ class ActiveLearningWorkChain(WorkChain):
         MACE models, and this check also outputted to the workchain using the
         namespace `stop_md_seed_no_disagreement`.
         """
+        # TODO: Update this
         if self.inputs.dft_method == "vasp":
             try:
                 dft_calcs = len(self.ctx.dft_struct_seed_calcs)
@@ -1486,20 +1492,28 @@ class ActiveLearningWorkChain(WorkChain):
         elif self.inputs.dft_method == "mace":
             try:
                 dft_calcs = len(self.ctx.dft_struct_seed_calcs)
-                self.report(f"Gathered {dft_calcs} MACE DFT calculations.")
+                self.report(f"Gathered {dft_calcs} MACE evaluations.")
 
-                return_list = mdb_al_ut.gather_dft_calcs_mace(
-                    [node.uuid for node in self.ctx.dft_struct_seed_calcs]
+                return_list_path = mdb_al_ut.gather_dft_calcs_mace(
+                    dft_calc_list=[
+                        node.uuid for node in self.ctx.dft_struct_seed_calcs
+                    ],
+                    results_dir=str(self.ctx.results_dir),
                 )
             except AttributeError:
-                return_list = List([])
+                return_list_path = ""
 
-        self.out("dft_calcs", return_list)  # list[dict]
+        # File containing structures
+        if return_list_path:
+            self.out("dft_calcs_path", return_list_path)
+
+        # SinglefileData for the MACE model with the best performance
+        self.out("m0_model_file", self.ctx.best_model_file)
+
         self.out(
             "stop_md_seed_no_disagreement",
-            mdb_al_ut.check_md_seed_agreement(return_list),
+            mdb_al_ut.check_md_seed_agreement(return_list_path),
         )
-        self.out("m0_model_file", self.ctx.best_model_file)
 
 
 class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
@@ -1525,14 +1539,6 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
                 "database_training",
             ],
         )
-
-        # spec.expose_outputs(
-        #     ActiveLearningWorkChain,
-        #     # exclude=[
-        #     #     "final_training_db",
-        #     #     "final_model_file",
-        #     # ],
-        # )
 
         spec.outline(
             # Load the initial database (D_ini), that will be used as the
@@ -1635,15 +1641,15 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
         generation database.
         """
         # Updating current training seed
-        seed_gen_db = mdb_al_ut.load_database(self.ctx.seed_db_path)
-        training_db = mdb_al_ut.load_database(self.ctx.training_db_path)
-        # self.ctx.seed_gen_db = self.outputs["upd_seed_gen_db"]
-        # self.ctx.inputs.seed_gen_db = self.outputs["upd_seed_gen_db"]
-
-        last_wc = self.ctx.last_workchain_completed
-
         try:
-            cnt_dft_calcs = len(last_wc.outputs["dft_calcs"])
+            seed_gen_db = mdb_al_ut.load_database(self.ctx.seed_db_path)
+            training_db = mdb_al_ut.load_database(self.ctx.training_db_path)
+            last_wc = self.ctx.last_workchain_completed
+            dft_calcs = ase_read(
+                last_wc.outputs["dft_calcs_path"].value, format="extxyz", index=":"
+            )
+
+            cnt_dft_calcs = len(dft_calcs)
 
         except KeyError:
             cnt_dft_calcs = 0
@@ -1652,7 +1658,7 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             self.report(f"Adding {cnt_dft_calcs} DFT calculations to DB.")
 
             # Adding calculations to training database and seed_generation database
-            for dft_calc in last_wc.outputs["dft_calcs"]:
+            for dft_calc in dft_calcs:
                 # Converting serialized structures to Atoms object.
                 if isinstance(dft_calc, dict):
                     dft_calc = mdb_al_ut.aiida_serialized_ase_dict_to_atoms(dft_calc)
@@ -1675,6 +1681,16 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             )
 
             self.report("Database files updated.")
+
+            # Removing teporary files from the AL loop step.
+            tmp_folder_path: Path = self.ctx.results_dir / "run_tmp_data"
+
+            # Can't use Path.walk() here as it's not available in Python 3.9
+            # this will be added if the library is updated to Python 3.12
+            for _, _, files in os.walk(top=tmp_folder_path):
+                for file in files:
+                    if "md_seed_structures" not in file:
+                        (tmp_folder_path / file).unlink(missing_ok=True)
 
         self.report(
             f"Iteration {self.ctx.iteration}: "
@@ -1879,11 +1895,12 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
         current_md_seed_structs = current_MD_seed_serialized
 
         # Saving the current md seed into the result directory as a file.
-        results_dir = mdb_al_ut.get_results_dir_path(
-            result_dir_path=self.inputs.active_learning.results_dir.value, node=self.node
+        self.ctx.results_dir = mdb_al_ut.get_results_dir_path(
+            result_dir_path=self.inputs.active_learning.results_dir.value,
+            node=self.node,
         )
         self.ctx.current_md_seed_structs_path = (
-            f"{results_dir}/md_seed_structures-"
+            f"{self.ctx.results_dir}/run_tmp_data/md_seed_structures-"
             f"{self.ctx.iteration}.pkl"
         )
 

--- a/src/MatDBForge/workflows/active_learning.py
+++ b/src/MatDBForge/workflows/active_learning.py
@@ -84,7 +84,9 @@ class ActiveLearningWorkChain(WorkChain):
         spec.input(
             "al_keep_struct_every_n_ps", valid_type=Float, serializer=to_aiida_type
         )
-        spec.input("current_md_seed_structs", valid_type=List, serializer=to_aiida_type)
+        spec.input(
+            "current_md_seed_structs_path", valid_type=Str, serializer=to_aiida_type
+        )
         spec.input("seed_db_path", valid_type=Str, serializer=to_aiida_type)
         spec.input("training_db_path", valid_type=Str, serializer=to_aiida_type)
         spec.input(
@@ -580,7 +582,10 @@ class ActiveLearningWorkChain(WorkChain):
 
             builder.settings = Dict(builder_settings)
 
-            for idx, curr_structure in enumerate(self.inputs.current_md_seed_structs):
+            with open(self.inputs.current_md_seed_structs_path.value, "rb") as f:
+                current_md_seed_structs = pickle.load(f)
+
+            for idx, curr_structure in enumerate(current_md_seed_structs):
                 # Structures are stored as a dict in order to be json-serializable
                 for key in ["pbc", "cell", "numbers", "positions", "forces"]:
                     curr_structure[key] = np.array(curr_structure[key])
@@ -697,7 +702,17 @@ class ActiveLearningWorkChain(WorkChain):
             )
 
         # Creating a DataFrame with all the results
-        self.ctx.md_seed_results_df = pd.DataFrame(new_rows)
+        md_seed_results_df = pd.DataFrame(new_rows)
+
+        results_dir = mdb_al_ut.get_results_dir_path(
+            result_dir_path=self.inputs.results_dir.value, node=self.node
+        )
+        # Saving the DataFrame into the result directory as a file.
+        self.ctx.md_seed_results_df_path = (
+            f"{results_dir}/md_seed_results_df_step-"
+            f"{self.inputs.al_loop_iteration.value}.pkl"
+        )
+        md_seed_results_df.to_pickle(path=self.ctx.md_seed_results_df_path)
 
     def gather_energies_from_workchain(self, workchain_results):
         """
@@ -897,7 +912,12 @@ class ActiveLearningWorkChain(WorkChain):
     def check_commitee_results(self):
         self.report("Evaluating trajectories with models...")
 
-        for row in self.ctx.md_seed_results_df.iterrows():
+        # Reading md seed results DataFrame
+        md_seed_results_df: pd.DataFrame = pd.read_pickle(
+            self.ctx.md_seed_results_df_path
+        )
+
+        for row in md_seed_results_df.iterrows():
             # self.report(f"Checking struct {row[0]} results with all models...")
             curr_traj = row[1]["trajectory"]
 
@@ -984,15 +1004,17 @@ class ActiveLearningWorkChain(WorkChain):
 
                     updated_ene_dict = row[1]["energy"]
                     updated_ene_dict.update({model_name: energies})
-                    self.ctx.md_seed_results_df.at[row[0], "energy"] = updated_ene_dict
+                    md_seed_results_df.at[row[0], "energy"] = updated_ene_dict
                     # TODO: Check if this is the proper way of gathering the forces
                     # forces_list = np.array(forces_list)
                     # forces_norm = np.linalg.norm(forces_list, axis=2)
                     # total_force_norm_per_frame = forces_norm.sum(axis=1)
 
-                    self.ctx.md_seed_results_df.at[row[0], "forces"][model_name] = (
+                    md_seed_results_df.at[row[0], "forces"][model_name] = (
                         forces_list  # total_force_norm_per_frame
                     )
+
+        md_seed_results_df.to_pickle(path=self.ctx.md_seed_results_df_path)
 
     def check_committee_results_calcjob(self):
         self.report("Evaluating trajectories with committee models...")
@@ -1017,8 +1039,13 @@ class ActiveLearningWorkChain(WorkChain):
             )
             commitee_dict[self.ctx.best_model_name] = self.ctx.best_model_file
 
+        # Reading md seed results DataFrame
+        md_seed_results_df: pd.DataFrame = pd.read_pickle(
+            self.ctx.md_seed_results_df_path
+        )
+
         # Checking committee predictions for every trajectory
-        for row in self.ctx.md_seed_results_df.iterrows():
+        for row in md_seed_results_df.iterrows():
             curr_traj = row[1]["trajectory"]
 
             # Run training and save new model file
@@ -1090,7 +1117,12 @@ class ActiveLearningWorkChain(WorkChain):
         self.report("Gathering committee evaluation...")
 
         # # REMOVE: Testing only
-        # self.ctx.md_seed_results_df.to_pickle("/tmp/md_seed_results_df")
+        # md_seed_results_df.to_pickle("/tmp/md_seed_results_df")
+
+        # Reading md seed results DataFrame
+        md_seed_results_df: pd.DataFrame = pd.read_pickle(
+            self.ctx.md_seed_results_df_path
+        )
 
         for curr_calc in self.ctx.committee_results:
             # Skipping calculation if training hasn't finished correctly.
@@ -1106,11 +1138,9 @@ class ActiveLearningWorkChain(WorkChain):
 
             # Find row matching the calculation using curr_unique_id and
             # current_temperature
-            row_index = self.ctx.md_seed_results_df[
-                self.ctx.md_seed_results_df.unique_id == curr_unique_id
-            ][self.ctx.md_seed_results_df.md_temperature == curr_md_temperature].index[
-                0
-            ]
+            row_index = md_seed_results_df[
+                md_seed_results_df.unique_id == curr_unique_id
+            ][md_seed_results_df.md_temperature == curr_md_temperature].index[0]
 
             # Collect energies from dict using model name
             energies_dict = curr_calc.outputs.energy_result_dict.get_dict()
@@ -1120,9 +1150,9 @@ class ActiveLearningWorkChain(WorkChain):
                 energies = np.array(energies_list)
 
                 # Updating current energy dict with the new results from every model
-                self.ctx.md_seed_results_df.loc[[row_index], "energy"][row_index][
-                    model_name
-                ] = energies
+                md_seed_results_df.loc[[row_index], "energy"][row_index][model_name] = (
+                    energies
+                )
 
             # Collect forces from dict using model name
             forces_collection = curr_calc.outputs.forces_result_dict.get_dict()
@@ -1130,16 +1160,24 @@ class ActiveLearningWorkChain(WorkChain):
                 forces_list = [forces for forces in forces_model_list]
 
                 # Updating current forces dict with the new results from every model
-                self.ctx.md_seed_results_df.loc[[row_index], "forces"][row_index][
-                    model_name
-                ] = np.array(forces_list)
+                md_seed_results_df.loc[[row_index], "forces"][row_index][model_name] = (
+                    np.array(forces_list)
+                )
+
+        # Updating md seed results DataFrame
+        md_seed_results_df.to_pickle(path=self.ctx.md_seed_results_df_path)
 
     def get_descriptors_from_md_results(self):
         # Getting descriptors for generated structures
         self.report("Getting descriptors for MD generated structures...")
 
+        # Reading md seed results DataFrame
+        md_seed_results_df: pd.DataFrame = pd.read_pickle(
+            self.ctx.md_seed_results_df_path
+        )
+
         # Store all frames from the trajectory into a list
-        for _, row in self.ctx.md_seed_results_df.iterrows():
+        for _, row in md_seed_results_df.iterrows():
             # all_frames_list = []
             curr_traj = row["trajectory"]
             traj_frames = []
@@ -1224,6 +1262,11 @@ class ActiveLearningWorkChain(WorkChain):
         delete_indices = []
         dft_structures = []
 
+        # Reading md seed results DataFrame
+        md_seed_results_df: pd.DataFrame = pd.read_pickle(
+            self.ctx.md_seed_results_df_path
+        )
+
         # Gathering MD descriptor results and adding them to dataframe
         if self.inputs.check_extrapolation:
             for curr_calc in self.ctx.md_descriptor_results:
@@ -1247,28 +1290,27 @@ class ActiveLearningWorkChain(WorkChain):
 
                 # Find row matching the calculation using curr_unique_id and
                 # current_temperature
-                row_index = self.ctx.md_seed_results_df[
-                    self.ctx.md_seed_results_df.unique_id == curr_unique_id
-                ][
-                    self.ctx.md_seed_results_df.md_temperature == curr_md_temperature
-                ].index[0]
+                row_index = md_seed_results_df[
+                    md_seed_results_df.unique_id == curr_unique_id
+                ][md_seed_results_df.md_temperature == curr_md_temperature].index[0]
 
                 # Assign matching descriptors to the extrapolation column
                 desc_f_curr_row: list = md_descr_dict[curr_unique_id]
 
                 # Overwrite row in dataframe
-                self.ctx.md_seed_results_df.loc[[row_index], "extrapolation"] = (
-                    pd.Series(
-                        [desc_f_curr_row],
-                        index=self.ctx.md_seed_results_df.index[[row_index]],
-                    )
+                md_seed_results_df.loc[[row_index], "extrapolation"] = pd.Series(
+                    [desc_f_curr_row],
+                    index=md_seed_results_df.index[[row_index]],
                 )
+
+        # Updating md seed results DataFrame
+        md_seed_results_df.to_pickle(path=self.ctx.md_seed_results_df_path)
 
         # Every row contains the results of MD for a single structure, which are:
         # trajectory, energies, forces, al_step, index_in_db, mdb_struct_type,
         # cluster, material_name, unique_id
         submitted_dft_cnt = 0
-        for db_row_idx, row in self.ctx.md_seed_results_df.iterrows():
+        for db_row_idx, row in md_seed_results_df.iterrows():
             # Make len(traj) sized array filled with False.
             extrapolating_frames = np.zeros(shape=len(row["trajectory"]))
             if self.inputs.check_extrapolation:
@@ -1472,7 +1514,7 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
             ActiveLearningWorkChain,
             namespace="active_learning",
             exclude=[
-                "current_md_seed_structs",
+                "current_md_seed_structs_path",
                 "current_md_seed_structs_idx",
                 "al_loop_iteration",
                 "train_seed_group",
@@ -1777,7 +1819,7 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
 
         Returns
         -------
-            None. The function updates self.ctx.current_md_seed_structs with the
+            None. The function updates current_md_seed_structs with the
             selected structures.
         """
         self.report(
@@ -1818,11 +1860,11 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
 
         # The set of random structures selected from the seed generation
         # database to be used in training.
-        self.ctx.current_md_seed_structs = []
+        current_md_seed_structs = []
 
         # Populating training seed with the selected random structures
         for idx in selected_structs:
-            self.ctx.current_md_seed_structs.append(seed_gen_db[idx])
+            current_md_seed_structs.append(seed_gen_db[idx])
 
         self.report(
             f"Created MD seed with {seed_size}"
@@ -1830,11 +1872,26 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
         )
         # Adding current train seed to the context
         current_MD_seed_serialized = []
-        for curr_s in self.ctx.current_md_seed_structs:
+        for curr_s in current_md_seed_structs:
             curr_s = mdb_al_ut.serialize_ase(curr_s)
             current_MD_seed_serialized.append(curr_s)
 
-        self.ctx.inputs.current_md_seed_structs = current_MD_seed_serialized
+        current_md_seed_structs = current_MD_seed_serialized
+
+        # Saving the current md seed into the result directory as a file.
+        results_dir = mdb_al_ut.get_results_dir_path(
+            result_dir_path=self.inputs.active_learning.results_dir.value, node=self.node
+        )
+        self.ctx.current_md_seed_structs_path = (
+            f"{results_dir}/md_seed_structures-"
+            f"{self.ctx.iteration}.pkl"
+        )
+
+        with open(self.ctx.current_md_seed_structs_path, "wb") as seed_file:
+            pickle.dump(current_md_seed_structs, seed_file)
+        self.ctx.inputs.current_md_seed_structs_path = (
+            self.ctx.current_md_seed_structs_path
+        )
 
     def results_final(self):
         """


### PR DESCRIPTION
## Description

This branch contains AL Loop improvements related to the handling of large numbers of structures. When many long MD simulations are run, a lot of structures were generated, serialized and added to the database. Storing them into a file eliminated the need for serialization and processing, speeding up the AL loop significatively.

Structure filters using the IQR method are now applied to the energy and force evaluation when using MACE, as predictions can fail and result in large energies and forces which lower the quality of the trained models. These filters should reduce the number of incorrect predictions being saved into the database.  

## Changes
   - Modified the active learning loop to use `SinglefileData` instead of structures in the AiiDA database to improve performance on large datasets.
   - Implemented MD energy and forces filtering using the IQR method to remove outliers and ensure data quality.
   - Introduced new parameters:
     - `openmp_threads`: Specifies the number of OpenMP threads for MACE CPU evaluation.
   - Updated utility functions:
     - `select_md_frames_to_keep`: Corrected frame interval calculation.
     - `get_results_dir_path`: Added optional check for the temporary directory.
     - `gather_dft_calcs_mace`: Switched to using `SinglefileData` for results storage and implemented IQR-based filtering for energy and forces.
     - Introduced `iqr_outlier_check` for filtering outliers using the IQR method.
   - Updated workflows to handle new outputs and parameters:
     - Modified `ActiveLearningWorkChain` to output path to DFT calculations file instead of a list of structures.
     - Cleaned up temporary files after each AL loop step.