### PR TITLE
21 implement small first md seed selection mode

### DIFF
--- a/src/MatDBForge/active_learning/active_learning_utils.py
+++ b/src/MatDBForge/active_learning/active_learning_utils.py
@@ -330,7 +330,8 @@ def generate_model_name():
     adj = r.word(include_parts_of_speech=["adjective"])
     noun = r.word(include_parts_of_speech=["noun"])
     verb = r.word(include_parts_of_speech=["verb"])
-    model_name = f"{adj}_{noun}_{verb}-{randint}"
+    model_name = f"{adj}_{noun}_{verb}-{randint}".replace(" ", "_")
+
     return model_name
 
 
@@ -607,7 +608,6 @@ def gather_dft_calcs_mace(dft_calc_list: list, results_dir: str) -> Str:
     # Adding structures to the initial DB
     for finished_dft_calc in dft_calc_list:
         calc_node = load_node(finished_dft_calc)
-        print("\ncalc_node: ", calc_node)
 
         try:
             # Gathering the calculation data from a extxyz stored as a SinglefileData.

--- a/src/MatDBForge/core/command_line.py
+++ b/src/MatDBForge/core/command_line.py
@@ -63,8 +63,15 @@ def create_active_learning_builder(toml_dict: dict):
     builder.active_learning.results_dir = al_conf["results_dir"]
     builder.active_learning.final_db_name = al_conf["final_db_name"]
     builder.active_learning.max_iterations = Int(int(al_conf["max_iterations"]))
-    builder.active_learning.seed_size_frac = float(al_conf["seed_size_frac"])
     builder.active_learning.check_extrapolation = al_conf["check_extrapolation"]
+
+    # AL seed settings
+    builder.active_learning.seed_size_frac = float(
+        toml_dict["al_seed"]["seed_size_frac"]
+    )
+    builder.active_learning.seed_select_settings = toml_dict["al_seed"][
+        "seed_select_settings"
+    ]
 
     builder.active_learning.committee_num_models = int(
         toml_dict["committee_eval"]["committee_num_models"]

--- a/src/MatDBForge/data/input_files/active_learning_settings.toml
+++ b/src/MatDBForge/data/input_files/active_learning_settings.toml
@@ -24,10 +24,6 @@ final_db_name = "final_data_test"
 # Maximum number of AL loop iterations.
 max_iterations = 3
 
-# Sets total structures in AL seed as a function of the training db size.
-# This influences the amount of MD calculations and E F evaluations.
-seed_size_frac = 0.01
-
 # Multiplier for model accuracy. Loosens model accuracy threshold.
 # Tighter thresholds (lower values) will result in more DFT calculations.
 # Any RMSE E/F values above chem_acc*chem_acc_multiplier will be considered wrong.
@@ -42,6 +38,27 @@ check_extrapolation = true
 
 # Selection of DFT calculator.
 dft_method = "vasp" # Options: "vasp", "mace"
+
+###############################################
+
+# AL seed generation settings
+[al_seed]
+# Sets total structures in AL seed as a function of the training db size.
+# This influences the amount of MD calculations and E F evaluations.
+seed_size_frac = 0.01
+
+[al_seed.seed_select_settings]
+# MD seed selection mode.
+# `random` selects random structures from the seed pool.
+# `small_first` selects random structures smaller than small_first_max_size
+# for the first small_first_max_iter iters.
+seed_select_type = "random" # random (default) / small_first
+
+# Maximum size in number of atoms for the structures selected with small_first mode
+small_first_max_size = 50
+
+# Apply small_first mode for the first n iterations
+small_first_max_iter = 5
 
 ###############################################
 
@@ -98,10 +115,10 @@ openmp_threads = 8
 
 # Settings for MACE evaluator
 [committee_eval.mace]
-device = "cuda"       # cpu, cuda
-default_dtype = "float32"     # float32, float64
+device = "cuda"           # cpu, cuda
+default_dtype = "float32" # float32, float64
 batch_size = 64
-compute_stress = true # whether or not to compute stress (true/false)
+compute_stress = true     # whether or not to compute stress (true/false)
 
 # AiiDA scheduler options for MACE Evaluations
 [committee_eval.metadata.options]

--- a/src/MatDBForge/workflows/active_learning.py
+++ b/src/MatDBForge/workflows/active_learning.py
@@ -73,6 +73,7 @@ class ActiveLearningWorkChain(WorkChain):
         spec.input("results_dir", valid_type=Str, serializer=to_aiida_type)
         spec.input("al_loop_iteration", valid_type=Int, serializer=to_aiida_type)
         spec.input("seed_size_frac", valid_type=Float, serializer=to_aiida_type)
+        spec.input("seed_select_settings", valid_type=Dict, serializer=to_aiida_type)
         spec.input("seed_size", valid_type=Int, serializer=to_aiida_type)
         spec.input("committee_num_models", valid_type=Int, serializer=to_aiida_type)
         spec.input("model_acc_multiplier", valid_type=Float, serializer=to_aiida_type)
@@ -108,7 +109,7 @@ class ActiveLearningWorkChain(WorkChain):
         spec.input("lammps_mace", valid_type=Dict)
         spec.input("dft_method", valid_type=Str, serializer=to_aiida_type)
         spec.input("dft_settings", valid_type=Dict)
-        spec.input("committee_eval", valid_type=Dict)
+        spec.input("committee_eval", valid_type=Dict, serializer=to_aiida_type)
         spec.input("check_extrapolation", valid_type=Bool, serializer=to_aiida_type)
         spec.input("gather_traj_cnt_lattice", valid_type=Bool, serializer=to_aiida_type)
         spec.input("use_kokkos", valid_type=Bool, serializer=to_aiida_type)
@@ -598,7 +599,7 @@ class ActiveLearningWorkChain(WorkChain):
                 struct_properties = curr_structure.properties
 
                 # Running a MD calculation for every T specified by the user
-                for temp_val in self.inputs.md_temperature_list_K:
+                for temp_val in self.inputs.temperature_list_K:
                     # TODO: Add to TOML. Check how to include parameters needed here as
                     # initial parameters (TOML)
                     curr_input = self.gen_md_input(
@@ -1608,7 +1609,6 @@ class ActiveLearningBaseWorkChain(BaseRestartWorkChain):
         self.ctx.seed_size = int(
             self.inputs.active_learning.seed_size_frac.value * len(database_training)
         )
-
         self.ctx.training_db_path = final_db_path
         shutil.copy(
             self.inputs.active_learning.init_db_path.value, self.ctx.training_db_path


### PR DESCRIPTION
## Introduce 'small_first' Mode and Bug Fixes

This pull request introduces the 'small_first' mode for MD seed selection to speed up the active learning loop by prioritizing smaller structures in early iterations. Additionally, it includes several bug fixes and improvements.
New Parameters in active_learning_settings.toml

To support the 'small_first' mode, three new parameters have been added:

- `seed_select_type`: Options are 'random' (default) or 'small_first'.
- `small_first_max_size`: Maximum atom count for structures in 'small_first' mode.
- `small_first_max_iter`: Number of iterations to apply 'small_first' mode.

### Implementation and Bug Fixes

- Implemented `small_first` seed selection mode in ActiveLearningBaseWorkChain:
    - Logic added to check and apply 'small_first' mode based on seed_select_settings and iteration count.
    - Seed generation database filtered to include only structures below small_first_max_size when 'small_first' mode is active.
- Corrected attribute name from `self.inputs.temperature_list_K` to `self.inputs.md_temperature_list_K` for MD calculations.
- Ensured model names generated by generate_model_name have underscores instead of spaces.
- Removed debug print statement from gather_dft_calcs_mace.

closes #21