### PR TITLE
print used configuration path when running `mdb_init_setup` after the first time

### DIFF
--- a/src/MatDBForge/core/code_utils.py
+++ b/src/MatDBForge/core/code_utils.py
@@ -194,15 +194,15 @@ def get_config_path() -> pathlib.Path:
     return pathlib.Path(config_path)
 
 
-def init_config_dir(config_dir):
+def init_config_dir(config_dir, config_file:str):
     """Create the configuration directory and the secrets file template."""
     # Create a 'mdb' directory inside the config directory
     config_dir = config_dir / 'mdb'
     config_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create a 'secrets.json' file inside the 'mdb' directory
+    # Create a 'config_file' file inside the 'mdb' directory
     try:
-        file_path = config_dir / 'secrets.json'
+        file_path = config_dir / config_file
 
         with open(file_path, 'x') as f:
             f.write('{\n' '"API_KEY": ""\n' '}')
@@ -211,10 +211,10 @@ def init_config_dir(config_dir):
         # to the owner only
         os.chmod(file_path, 0o700)
 
-        return config_dir
+        return True, config_dir
 
     except FileExistsError:
-        return None
+        return False, config_dir / config_file
 
 
 def get_cache_path() -> pathlib.Path:

--- a/src/MatDBForge/core/command_line/cli_run_initial_config.py
+++ b/src/MatDBForge/core/command_line/cli_run_initial_config.py
@@ -11,22 +11,32 @@ warnings.filterwarnings('ignore')
 def run_initial_config():
     mdb_cud.init_logger(source=pl.Path(__file__).stem, log_path='/tmp')
 
+    # Config file name
+    config_file_name = 'secrets.json'
+
     # Get config directory
     config_path = mdb_cud.get_config_path()
 
     # Create a mdb folder
-    config_dir = mdb_cud.init_config_dir(config_path)
+    created, config_dir = mdb_cud.init_config_dir(
+        config_path, config_file=config_file_name
+    )
 
-    if config_dir:
+    if created:
         mdb_cud.custom_print(
-            f"Enter your materials project API key in '{config_dir/'secrets.json'}'"
-            f" to finish the setup process."
-            "You can get your API key from https://next-gen.materialsproject.org/api",
+            f"Enter your materials project API key in '{config_dir / config_file_name}'"
+            f' to finish the setup process.'
+            'You can get your API key from https://next-gen.materialsproject.org/api',
             print_type='warn',
         )
     else:
         mdb_cud.custom_print(
-            "Initial configuration already done: 'secrets.json' already exists.", 'done'
+            (
+                f"Initial configuration already done: '{config_file_name}' already "
+                f"exists. Check the '{config_dir / config_file_name}' file to update "
+                'your MP API key.'
+            ),
+            'warn',
         )
 
     # Get cache directory


### PR DESCRIPTION
The mdb_init_setup now will print the current location of the configuration if it exists:

```log
[02/01/25 13:39:38] [ i ]    Logging in '/tmp/mdb_cli_run_initial_config_jwazed5h.log'
[02/01/25 13:39:38] [ ! ]    Initial configuration already done: 'secrets.json' already exists. Check the
                             '/home/xxxx/.config/mdb/secrets.json/secrets.json' file to update your MP API key.
[02/01/25 13:39:38] [ ✔ ]    Cache directory already exists. Nothing done.
```

This will make it easier for users to modify their API keys or future configuration options.
Fixes #64 .