### PR TITLE
fix(core): fixes wrong path definition on `init_config_dir`.

### DIFF
--- a/src/MatDBForge/core/code_utils.py
+++ b/src/MatDBForge/core/code_utils.py
@@ -214,7 +214,7 @@ def init_config_dir(config_dir, config_file:str):
         return True, config_dir
 
     except FileExistsError:
-        return False, config_dir / config_file
+        return False, config_dir
 
 
 def get_cache_path() -> pathlib.Path:


### PR DESCRIPTION
Related to #64 