### PR TITLE
pinned torch version to 2.4.0 to ensure compatibility with mace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "aiida-lammps==1.0.1",
     "aiida-vasp==3.1.0",
     "wonderwords==2.2.0",
-    "torch",
+    "torch==2.4.0",
     "shapely",
     "pymatgen",
     "python-slugify[unidecode]",


### PR DESCRIPTION
Related to #68.

Following the [MACE installation instructions](https://github.com/ACEsuit/mace#installation):

> Training with float64 is not supported with PyTorch 2.1 but is supported with 2.2 and later. PyTorch 2.4.1 is not supported.

Leaving the PyTorch version unpinned resulted in PyTorch 2.6 being installed, which is **not compatible** with MACE `0.3.7`, as seen in #68.

To ensure compatibility, this PR **pins `torch==2.4.0`**, which has been tested to work correctly with MACE `0.3.7`.