### PR TITLE
Replace default ASE NPT with MTKNPT 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: trailing-whitespace
-        exclude: ^src/MatDBForge/data/
+      # - id: trailing-whitespace
+      #   exclude: ^src/MatDBForge/data/
       - id: end-of-file-fixer
         exclude: ^src/MatDBForge/data/
       - id: check-yaml

--- a/docs/source/input_active_learning.md
+++ b/docs/source/input_active_learning.md
@@ -376,10 +376,27 @@ MD simulation parameters for safeguard. These settings will override the general
   - **Type**: `(float)`
   - **Default**: `0.003`.
 
+- {alt}`md_thermostat`:
+  - **Description**: Ensemble used in the MD simulation. The ensemble parameter changes the selection of the ASE integrator and thermostat and barostat. `langevin` and `nvt` ensembles use the ASE Langevin thermostat. `npt` and `npt-mtk` uses ASE's implementation of the Full Martyna-Tobias-Klein (MTK) method [^1], similar to the one used for NPT in LAMMPS. The `npt-melchionna` ensemble uses a combined Nose-Hoover and Parrinello-Rahman  method, as proposed by Melchionna et al. and provided in ASE as the default NPT class. However, this implementation is not recommended for use by ASE due stability issues!  
+[^1] MTKNPT: https://ase-lib.org/ase/md.html#full-martyna-tobias-klein-mtk-dynamics
+  - **Type**: `(optional, str)`
+  - **Default**: `'langevin'`.
+  - Possible values are: `langevin`, `nvt`, `npt`, `npt-mtk`, `npt-melchionna`.
+
 - {alt}`langevin_friction_ps-1`:
-  - **Description**: Friction coefficient for the Langevin thermostat in ps⁻¹.
+  - **Description**: Friction coefficient for the Langevin thermostat in picoseconds.
   - **Type**: `(float)`
   - **Default**: `10.0`.
+
+- {alt}`npt_ttime_fs`:
+  - **Description**: Time constant for temperature coupling in NPT thermostat in femtoseconds.
+  - **Type**: `(float)`
+  - **Default**: `100.0`.
+
+- {alt}`npt_ptime_fs`:
+  - **Description**: Time constant for pressure coupling in NPT thermostat in femtoseconds.
+  - **Type**: `(float)`
+  - **Default**: `25.0`.
 
 - {alt}`gather_traj_cnt_lattice`:
   - **Description**: Consider constant lattice when gathering trajectories.
@@ -427,12 +444,6 @@ MD simulation parameters for safeguard. These settings will override the general
   - **Description**: Number of CPUs to use for structures larger than `large_struct_size`.
   - **Type**: `(optional, int)`
   - **Default**: `16`.
-
-- {alt}`md_thermostat`:
-  - **Description**: Thermostat used in the MD simulation.
-  - **Type**: `(optional, str)`
-  - **Default**: `'langevin'`.
-  - Possible values are: `langevin`, `nvt`, `npt`, `nose-hoover`.
 
 ### Molecular Dynamics Settings - `[md]`
 
@@ -479,6 +490,27 @@ MD simulation parameters.
   - **Type**: `(float)`
   - **Default**: `0.003`.
 
+- {alt}`md_thermostat`:
+  - **Description**: Thermostat used in the MD simulation.
+  - **Type**: `(optional, str)`
+  - **Default**: `'langevin'`.
+  - Possible values are: `langevin`, `nvt`, `npt`, `nose-hoover`.
+
+- {alt}`npt_ttime_fs`:
+  - **Description**: Time constant for temperature coupling in NPT thermostat in femtoseconds.
+  - **Type**: `(float)`
+  - **Default**: `100.0`.
+
+- {alt}`npt_ptime_fs`:
+  - **Description**: Time constant for pressure coupling in NPT thermostat in femtoseconds.
+  - **Type**: `(float)`
+  - **Default**: `25.0`.
+
+- {alt}`md_stage_order`:
+  - **Description**: List containing the names of the stages, written in the order in which the MD stages will be applied. Each stage must be defined under `md.parameters.stages`.
+  - **Type**: `(optional, list[str])`
+  - **Default**: `[]`.
+
 - {alt}`langevin_friction_ps-1`:
   - **Description**: Friction coefficient for the Langevin thermostat in ps⁻¹.
   - **Type**: `(float)`
@@ -531,11 +563,9 @@ MD simulation parameters.
   - **Type**: `(optional, int)`
   - **Default**: `16`.
 
-- {alt}`md_thermostat`:
-  - **Description**: Thermostat used in the MD simulation.
-  - **Type**: `(optional, str)`
-  - **Default**: `'langevin'`.
-  - Possible values are: `langevin`, `nvt`, `npt`, `nose-hoover`.
+- {alt}`stages`:
+  - **Description**: Collection of named keys representing a particular stage of an MD simulation. These stages will be chained together and applied to single MD calculation job following the order defined in `md.parameters.md_stage_order`, resulting in a continuous MD calculation with different settings for every stage. Each stage key will contain contain settings to be applied during each stage, overriding the default MD settings specified under `md.parameters`. Each dictionary must contain a mandatory `use_during_al_steps` key, which is a string n integer representing the number of AL steps that the given stage will be run for. If not present, the stage will be ignored.
+  - **Type**: `(list[dict])`
 
 #### MD Trajectory Filters - `[md.filters]`
 

--- a/src/MatDBForge/active_learning/active_learning_utils.py
+++ b/src/MatDBForge/active_learning/active_learning_utils.py
@@ -1,4 +1,5 @@
 """General utility functions for the active learning workflows."""
+
 from __future__ import annotations
 
 import io
@@ -28,6 +29,7 @@ from ase.io import read as ase_read
 from ase.io import write as ase_write
 from ase.io.trajectory import TrajectoryWriter
 from ase.md.langevin import Langevin
+from ase.md.nose_hoover_chain import MTKNPT
 from ase.md.npt import NPT
 from ase.md.velocitydistribution import (
     MaxwellBoltzmannDistribution,
@@ -136,6 +138,8 @@ def md_apply_temperature_ramp(dyn, total_steps, T_start, T_end, T_list):
     # Adding current T value to the list
     if dyn.todict().get('temperature_K') is not None:
         T_list.append(dyn.todict().get('temperature_K'))
+    elif dyn._temperature_K is not None:
+        T_list.append(dyn._temperature_K)
     else:
         # convert eV to K
         T_list.append(dyn.temperature * 11604.5250061657)
@@ -144,7 +148,10 @@ def md_apply_temperature_ramp(dyn, total_steps, T_start, T_end, T_list):
     current_temperature = T_start + (T_end - T_start) * dyn.nsteps / total_steps
 
     # Set the temperature in units of energy
-    dyn.set_temperature(temperature_K=current_temperature)
+    if hasattr(dyn, 'set_temperature'):
+        dyn.set_temperature(temperature_K=current_temperature)
+    else:
+        dyn._temperature_K = current_temperature
 
     # Adding T value to info dict
     dyn.atoms.info['md_temperature'] = current_temperature
@@ -815,6 +822,12 @@ def run_mace_md_ase(
     else:
         friction = md_params['timestep_duration_ps'] * 100
 
+    if md_params.get('npt_ttime_fs'):
+        npt_ttime_fs = md_params.get('npt_ttime_fs', 100.0)
+
+    if md_params.get('npt_ptime_fs'):
+        npt_ptime_fs = md_params.get('npt_ptime_fs', 25.0)
+
     num_steps = md_params['num_steps']
     write_interval = md_params.get('md_write_interval', 1)
     thermostat = md_params.get('md_thermostat', 'langevin')
@@ -906,25 +919,54 @@ def run_mace_md_ase(
                 logfile=log_folder / f'md_info-{T_start}K.log',
                 loginterval=log_interval,
             )
-        case 'nose-hoover' | 'npt':
-            # Change the simulation box to remove any small numbers not in the diagonal
+        case  'npt-melchionna':
+            # Change the simulation box to remove any small numbers in the diagonal
             # of the box matrix
-            box = init_conf.get_cell()
-            box[np.abs(box) < 1e-2] = 0
-            init_conf.set_cell(box)
+            from ase.geometry import cellpar_to_cell
+
+            cellpar = init_conf.get_cell().cellpar()
+            new_cell_matrix = cellpar_to_cell(cellpar)
+            init_conf.set_cell(new_cell_matrix, scale_atoms=True)
 
             dyn = NPT(
                 atoms=init_conf,
                 timestep=(timestep_ps * 1000) * units.fs,
                 temperature_K=T_start,
                 externalstress=0,
-                ttime=100 * units.fs,
-                pfactor=None,
+                ttime=npt_ttime_fs * units.fs,
+                pfactor=npt_ptime_fs * units.fs,
                 logfile=log_folder / f'md_info-{T_start}K.log',
                 loginterval=log_interval,
             )
-    mdb_cut.custom_print('Running MD simulation using settings:', 'info')
-    rprint(md_params)
+        case 'npt' | 'npt-mtk':
+            timestep = (timestep_ps * 1000) * units.fs
+            dyn = MTKNPT(
+                atoms=init_conf,
+                timestep=timestep,
+                temperature_K=T_start,
+                pressure_au=0,
+                tdamp=100 * timestep,
+                pdamp=1000 * timestep,
+                tchain=3,
+                pchain=3,
+                tloop=1,
+                ploop=1,
+            )
+
+    # Handling logging of the MD parameters
+    curr_logger = mdb_cut.custom_print('Running MD simulation using settings:', 'info')
+    rich_handler = [
+        handl for handl in curr_logger.handlers if handl.name == 'mdb_rich_handler'
+    ]
+    rich_handler = rich_handler[0] if len(rich_handler) > 0 else None
+    file_handler = [
+        handl for handl in curr_logger.handlers if handl.name == 'mdb_file_handler'
+    ]
+    file_handler = file_handler[0] if len(file_handler) > 0 else None
+    if rich_handler:
+        rprint(md_params)
+    if file_handler:
+        mdb_cut.custom_print(f'{md_params}', 'none', extras={'block': 'console'})
 
     # Attach the thermostat function to increase the temperature
     # linearly from T_start to T_end

--- a/src/MatDBForge/active_learning/extrapolation/concave_hull.py
+++ b/src/MatDBForge/active_learning/extrapolation/concave_hull.py
@@ -330,7 +330,7 @@ def get_concave_hull_python(
 
             if alpha <= alpha_lower_bound:
                 mdb_cut.custom_print(
-                    f'Alpha has reached the minimum threshold of {alpha_lower_bound}.'
+                    f'Alpha has reached the minimum threshold of {alpha_lower_bound}. '
                     'Stopping adjustments.',
                     'warn',
                 )
@@ -340,11 +340,12 @@ def get_concave_hull_python(
                 mdb_cut.custom_print(
                     (
                         f'Current fraction of points outside hull is'
-                        f' {frac_outside:.4f}, above the allowed'
-                        f' {frac_points_allowed_out:.4f} threshold.'
+                        f' {frac_outside:.4e}, above the allowed'
+                        f' {frac_points_allowed_out:.4e} threshold.'
                     ),
                     'warn',
                 )
+                mdb_cut.custom_print(f'Area of concave hull: {shape.area:.4e}', 'info')
                 mdb_cut.custom_print(f'Decreasing alpha to: {alpha:.4f}', 'info')
                 last_alpha = alpha
                 num_attempts += 1
@@ -352,8 +353,8 @@ def get_concave_hull_python(
                 mdb_cut.custom_print(
                     (
                         f'Current fraction of points outside hull'
-                        f' is {frac_outside:.4f}, '
-                        f' below the allowed {frac_points_allowed_out:.4f} threshold.'
+                        f' is {frac_outside:.4e}, '
+                        f' below the allowed {frac_points_allowed_out:.4e} threshold.'
                     ),
                     'info',
                 )

--- a/src/MatDBForge/core/code_utils.py
+++ b/src/MatDBForge/core/code_utils.py
@@ -7,6 +7,7 @@ import pathlib
 import subprocess as sb
 import tempfile
 import warnings
+from logging import LogRecord
 
 import qrcode
 from packaging.version import Version
@@ -67,6 +68,8 @@ def get_console_handler():
     )
     formatter_con = logging.Formatter('%(message)s')
     ch.setFormatter(formatter_con)
+    ch.set_name('mdb_rich_handler')
+    ch.addFilter(create_handler_filters('console'))
     return ch, console
 
 
@@ -78,6 +81,13 @@ def logging_set_levels():
     logging.addLevelName(25, '[ ✔ ]')
     logging.addLevelName(30, '[ ! ]')
     logging.addLevelName(40, '[ X ]')
+
+
+def create_handler_filters(handler: str):
+    def handler_filter(record: LogRecord):
+        return not (hasattr(record, 'block') and record.block == handler)
+
+    return handler_filter
 
 
 def init_logger(source, log_path=None, show_log_path=True):
@@ -99,6 +109,8 @@ def init_logger(source, log_path=None, show_log_path=True):
         )
 
     fh = logging.FileHandler(filename=filename, mode='a+')
+    fh.set_name('mdb_file_handler')
+    fh.addFilter(create_handler_filters('file'))
     fh.setLevel(logging.DEBUG)
     formatter_fil = logging.Formatter('%(asctime)s - %(levelname)s - %(shortmsg)s')
     fh.setFormatter(formatter_fil)
@@ -124,9 +136,14 @@ class LevelNameFilter(logging.Filter):
 
 
 def custom_print(
-    string: str, print_type: str = 'default', end='\n', extra_tab=False, logger=None
+    string: str,
+    print_type: str = 'default',
+    end='\n',
+    extra_tab=False,
+    logger=None,
+    extras: dict = None,
 ):
-    """Prints a string using different formatting styles for easier debugging.
+    r"""Prints a string using different formatting styles for easier debugging.
 
     Parameters
     ----------
@@ -140,6 +157,17 @@ def custom_print(
             - `done/ok`: prefixes [ ✔ ] before the string.
             - `error/problem`: prefixes [ X ] before the string.
             - `none/clean/clear/empty`: leaves an empty space before the string.
+    end : str, optional, `default=\n`
+        String appended after the last value, default a newline.
+    extra_tab : bool, optional, `default=False`
+        If True, adds an extra tab before the string.
+    logger : logging.Logger, optional, `default=None`
+        Logger to use for printing. If None, a new logger named 'mdb' is created
+
+    Returns
+    -------
+    logging.Logger
+        Logger used for printing the string
     """
     # normal = "\u001b[0m"
 
@@ -163,21 +191,21 @@ def custom_print(
         logger.log(
             level=20,
             msg=f'{prefix}{normal}{extra_tab}{string}',
-            extra={'shortmsg': string},
+            extra={'shortmsg': string, **(extras if extras else {})},
         )
     elif print_type in ['warn', 'warning', 'warn-soft', 'warning-soft']:
         # prefix = "\u001b[38;5;220m [ ! ]"
         logger.log(
             level=30,
             msg=f'{prefix}{normal}{extra_tab}{string}',
-            extra={'shortmsg': string},
+            extra={'shortmsg': string, **(extras if extras else {})},
         )
     elif print_type in ['extra', 'debug']:
         # prefix = "\u001b[38;5;8m [···]"
         logger.log(
             level=10,
             msg=f'{prefix}{normal}{extra_tab}{string}',
-            extra={'shortmsg': string},
+            extra={'shortmsg': string, **(extras if extras else {})},
         )
     if print_type in ['none', 'clean', 'clear', 'empty']:
         prefix = ''
@@ -186,7 +214,7 @@ def custom_print(
         logger.log(
             level=15,
             msg=f'{prefix}{normal}{extra_tab}{string}',
-            extra={'shortmsg': string},
+            extra={'shortmsg': string, **(extras if extras else {})},
         )
     elif print_type in ['done', 'ok']:
         # prefix = "\u001b[38;5;46m [ ✔ ]"
@@ -196,15 +224,16 @@ def custom_print(
         logger.log(
             level=25,
             msg=f'{prefix}{normal}{extra_tab}{string}',
-            extra={'shortmsg': string},
+            extra={'shortmsg': string, **(extras if extras else {})},
         )
     if print_type in ['error', 'problem']:
         # prefix = "\u001b[38;5;1m [ X ]"
         logger.log(
             level=40,
             msg=f'{prefix}{normal}{extra_tab}{string}',
-            extra={'shortmsg': string},
+            extra={'shortmsg': string, **(extras if extras else {})},
         )
+    return logger
 
 
 def deprecated(reason, since_ver=None):

--- a/src/MatDBForge/core/command_line/command_line_utils.py
+++ b/src/MatDBForge/core/command_line/command_line_utils.py
@@ -325,7 +325,7 @@ def evaluate_dependency(depends_on, config_data, root_config_data):
                 return False
 
         # Check if the actual value matches the expected value
-        return current_data == expected_value
+        return current_data in expected_value
 
     except (KeyError, TypeError, AttributeError):
         # If we can't find the dependency path, assume dependency is not met

--- a/src/MatDBForge/data/config_schema.yaml
+++ b/src/MatDBForge/data/config_schema.yaml
@@ -1048,11 +1048,43 @@ active_learning:
         type: float
         mandatory: true
         default: 0.003
+      md_thermostat:
+        description: "Ensemble used in the MD simulation. The ensemble parameter changes the selection of the ASE integrator and thermostat and barostat. `langevin` and `nvt` ensembles use the ASE Langevin thermostat. `npt` and `npt-mtk` uses ASE's implementation of the Full Martyna-Tobias-Klein (MTK) method [^1], similar to the one used for NPT in LAMMPS. The `npt-melchionna` ensemble uses a combined Nose-Hoover and Parrinello-Rahman  method, as proposed by Melchionna et al. and provided in ASE as the default NPT class. However, this implementation is not recommended for use by ASE due stability issues!  \n[^1] MTKNPT: https://ase-lib.org/ase/md.html#full-martyna-tobias-klein-mtk-dynamics"
+        type: str
+        mandatory: false
+        default: "langevin"
+        choices:
+          [
+            "langevin",
+            "nvt",
+            "npt",
+            "npt-mtk",
+            "npt-melchionna",
+          ]
       langevin_friction_ps-1:
-        description: "Friction coefficient for the Langevin thermostat in ps⁻¹."
+        description: "Friction coefficient for the Langevin thermostat in picoseconds."
         type: float
         mandatory: true
         default: 10.0
+        depends_on:
+          key: active_learning.safeguard.md_parameters.md_thermostat
+          value: ["nvt", "langevin"]
+      npt_ttime_fs:
+        description: "Time constant for temperature coupling in NPT thermostat in femtoseconds."
+        type: float
+        mandatory: true
+        default: 100.0
+        depends_on:
+          key: active_learning.safeguard.md_parameters.md_thermostat
+          value: "npt"
+      npt_ptime_fs:
+        description: "Time constant for pressure coupling in NPT thermostat in femtoseconds."
+        type: float
+        mandatory: true
+        default: 25.0
+        depends_on:
+          key: active_learning.safeguard.md_parameters.md_thermostat
+          value: ["npt", nose-hoover]
       gather_traj_cnt_lattice:
         description: "Consider constant lattice when gathering trajectories."
         type: bool
@@ -1100,12 +1132,6 @@ active_learning:
         type: int
         mandatory: false
         default: 16
-      md_thermostat:
-        description: "Thermostat used in the MD simulation."
-        type: str
-        mandatory: false
-        default: "langevin"
-        choices: ["langevin", "nvt", "npt", "nose-hoover"]
 
   md:
     name: "md"
@@ -1148,6 +1174,34 @@ active_learning:
         type: float
         mandatory: true
         default: 0.003
+      md_thermostat:
+        description: "Thermostat used in the MD simulation."
+        type: str
+        mandatory: false
+        default: "langevin"
+        choices: ["langevin", "nvt", "npt", "nose-hoover"]
+      npt_ttime_fs:
+        description: "Time constant for temperature coupling in NPT thermostat in femtoseconds."
+        type: float
+        mandatory: true
+        default: 100.0
+        depends_on:
+          key: active_learning.safeguard.md_parameters.md_thermostat
+          value: "npt"
+      npt_ptime_fs:
+        description: "Time constant for pressure coupling in NPT thermostat in femtoseconds."
+        type: float
+        mandatory: true
+        default: 25.0
+        depends_on:
+          key: active_learning.safeguard.md_parameters.md_thermostat
+          value: ["npt", nose-hoover]
+      md_stage_order:
+        description: "List containing the names of the stages, written in the order in which the MD stages will be applied. Each stage must be defined under `md.parameters.stages`."
+        type: list[str]
+        mandatory: false
+        default: []
+        example: ["stage1", "nvt_1", "stage_2", "npt_1", ...]
       langevin_friction_ps-1:
         description: "Friction coefficient for the Langevin thermostat in ps⁻¹."
         type: float
@@ -1200,12 +1254,28 @@ active_learning:
         type: int
         mandatory: false
         default: 16
-      md_thermostat:
-        description: "Thermostat used in the MD simulation."
-        type: str
-        mandatory: false
-        default: "langevin"
-        choices: ["langevin", "nvt", "npt", "nose-hoover"]
+      stages:
+        # depends_on:
+        #   key: md.parameters.md_stage_order
+        #   value: "*"
+        description: "Collection of named keys representing a particular stage of an MD simulation. These stages will be chained together and applied to single MD calculation job following the order defined in `md.parameters.md_stage_order`, resulting in a continuous MD calculation with different settings for every stage. Each stage key will contain contain settings to be applied during each stage, overriding the default MD settings specified under `md.parameters`. Each dictionary must contain a mandatory `use_during_al_steps` key, which is a string n integer representing the number of AL steps that the given stage will be run for. If not present, the stage will be ignored."
+        type: list[dict]
+        mandatory: true
+        dynamic_keys: true
+        flatten: true
+        schema:
+          use_during_al_steps:
+            description: "String representing a number of AL steps or interval of AL steps in which the stage will be used. For example, `1` means that the stage will be used during step 1, while `3-6` means that the stage will be used from AL step 3 to AL step 6 (inclusive). The example `'1, 3, 4, 5-9, 11' would execute the current stage for steps 1, 3, 4, 5, 6, 7, 8, 9, and 11."
+            type: str
+            mandatory: true
+            example: "1, 3, 4, 5-9, 11"
+          md_parameters:
+            wildcard_entry: true
+            wildcard_path: "md.parameters.*"
+            wildcard_level: 1
+        #   description: "Symbol of the element defining the cluster."
+        #   type: str
+        #   mandatory: false
     filters:
       name: "filters"
       name_pretty: "MD Trajectory Filters"

--- a/src/MatDBForge/workflows/simple_active_learning.py
+++ b/src/MatDBForge/workflows/simple_active_learning.py
@@ -280,32 +280,42 @@ class SimpleActiveLearningWorkChain(WorkChain):
             ]
         )
 
-        # Create a file handle
-        file_handler = logging.FileHandler(log_path)
-        file_handler.setLevel(1)
-        file_handler.addFilter(log_filter)
+        curr_logger_handlers = aiida_logger.handlers
 
-        # Create a formatter and set it for the file handler
-        file_formatter = logging.Formatter(
-            '[%(asctime)s] [%(levelname)s] - %(message)s',
-            datefmt='%m/%d/%y %H:%M:%S',
-        )
-        file_handler.setFormatter(file_formatter)
-        aiida_logger.addHandler(file_handler)
+        if not any(
+            [handl.name == 'mdb_file_handler' for handl in curr_logger_handlers]
+        ):
+            # Create a file handler
+            file_handler = logging.FileHandler(log_path)
+            file_handler.setLevel(1)
+            file_handler.set_name('mdb_file_handler')
+            file_handler.addFilter(log_filter)
 
-        # Adding console logger
-        console = Console(color_system='truecolor')
-        ch = RichHandler(
-            markup=True,
-            show_path=False,
-            log_time_format='[%d/%m/%y %H:%M:%S]',
-            omit_repeated_times=False,
-            console=console,
-        )
-        ch.setLevel(23)
-        formatter_con = logging.Formatter('%(message)s')
-        ch.setFormatter(formatter_con)
-        aiida_logger.addHandler(ch)
+            # Create a formatter and set it for the file handler
+            file_formatter = logging.Formatter(
+                '[%(asctime)s] [%(levelname)s] - %(message)s',
+                datefmt='%m/%d/%y %H:%M:%S',
+            )
+            file_handler.setFormatter(file_formatter)
+            aiida_logger.addHandler(file_handler)
+
+        if not any(
+            [handl.name == 'mdb_rich_handler' for handl in curr_logger_handlers]
+        ):
+            # Adding console logger
+            console = Console(color_system='truecolor')
+            ch = RichHandler(
+                markup=True,
+                show_path=False,
+                log_time_format='[%d/%m/%y %H:%M:%S]',
+                omit_repeated_times=False,
+                console=console,
+            )
+            ch.set_name('mdb_rich_handler')
+            ch.setLevel(23)
+            formatter_con = logging.Formatter('%(message)s')
+            ch.setFormatter(formatter_con)
+            aiida_logger.addHandler(ch)
 
     def step_setup(self):
         self.node.base.extras.set(
@@ -1258,7 +1268,7 @@ class SimpleActiveLearningWorkChain(WorkChain):
             self.report(f'Submission done for MD calculation: {future.pk}')
 
         self.report(
-            'All calculation submissions done.'
+            'All calculation submissions done. '
             f'Running MD for {len(self.ctx.process_committee_results)}'
             ' structures...'
         )
@@ -1267,7 +1277,7 @@ class SimpleActiveLearningWorkChain(WorkChain):
             requests.post(
                 f'https://ntfy.sh/{self.inputs.ntfysh_topic.value}',
                 data=(
-                    f'All calculation submissions done.'
+                    f'All calculation submissions done. '
                     f'Running MD for {len(self.ctx.process_committee_results)}'
                     ' structures...'
                 ),


### PR DESCRIPTION
* Added support for multiple MD ensembles (`langevin`, `nvt`, `npt`, `npt-mtk`, `npt-melchionna`) in both the documentation (`docs/source/input_active_learning.md`) and configuration schema (`src/MatDBForge/data/config_schema.yaml`). The ensemble now determines the choice of ASE integrator, thermostat, and barostat, with detailed documentation and schema validation. [[1]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879R379-R400) [[2]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879R493-R513) [[3]](diffhunk://#diff-b581b957344e8920a9877addb394a04b23e7bdf1e984b0bc77d033c4bdeb4ebdR1051-R1087)
* Introduced new configuration parameters for NPT simulations: `npt_ttime_fs` and `npt_ptime_fs`, which control the temperature and pressure coupling times, respectively. These are now documented, added to the config schema, and used in the MD execution code. [[1]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879R379-R400) [[2]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879R493-R513) [[3]](diffhunk://#diff-b581b957344e8920a9877addb394a04b23e7bdf1e984b0bc77d033c4bdeb4ebdR1051-R1087)
* Improved the handling of MD stages and their order via new configuration options (`md_stage_order`, `stages`), enabling more complex multi-stage MD workflows. [[1]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879R493-R513) [[2]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879L534-R568)
* Updated the MD execution logic (`src/MatDBForge/active_learning/active_learning_utils.py`) to support the new ensembles, including correct initialization of NPT simulations using either the Melchionna or MTK methods, and proper handling of cell matrices and temperature/pressure coupling parameters. [[1]](diffhunk://#diff-b6f08abbaf28c70470b011d41d3f3f26aee362aa68b071880e6b10bbf61f8ae3R32) [[2]](diffhunk://#diff-b6f08abbaf28c70470b011d41d3f3f26aee362aa68b071880e6b10bbf61f8ae3R825-R830) [[3]](diffhunk://#diff-b6f08abbaf28c70470b011d41d3f3f26aee362aa68b071880e6b10bbf61f8ae3L909-R969)
* Improved temperature ramp application in MD by ensuring compatibility with different integrator APIs and adding robustness for temperature tracking. [[1]](diffhunk://#diff-b6f08abbaf28c70470b011d41d3f3f26aee362aa68b071880e6b10bbf61f8ae3R141-R142) [[2]](diffhunk://#diff-b6f08abbaf28c70470b011d41d3f3f26aee362aa68b071880e6b10bbf61f8ae3R151-R154)
* Enhanced logging infrastructure by adding custom handler names and filters for console and file logging, and updating the `custom_print` utility to support extra metadata and return the logger instance for further use. [[1]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310R71-R72) [[2]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310R86-R92) [[3]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310R112-R113) [[4]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310L127-R146) [[5]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310R160-R170) [[6]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310L166-R208) [[7]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310L189-R217) [[8]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310L199-R236)
* Disabled the `trailing-whitespace` pre-commit hook for data files, improving commit workflow reliability.
* Minor import and docstring adjustments for clarity and future compatibility. [[1]](diffhunk://#diff-b6f08abbaf28c70470b011d41d3f3f26aee362aa68b071880e6b10bbf61f8ae3R2) [[2]](diffhunk://#diff-6ca36006852a7623858a4f83b23613a2821a557f357a8f50829293efc30f5310R10)