### PR TITLE
AL fixes and improvements

### DIFF
--- a/src/MatDBForge/active_learning/safeguard/safeguard_scripts/mdb_run_safeguard_md.py
+++ b/src/MatDBForge/active_learning/safeguard/safeguard_scripts/mdb_run_safeguard_md.py
@@ -562,12 +562,14 @@ if __name__ == '__main__':
             # Only MACE is supported for now
             mdb_cut.custom_print('Generating descriptors...', 'info', logger=logger)
             if settings['descriptors'].get('descriptor_type', 'mace') == 'soap':
-                descriptor_dict, descriptor_arr = mdb_al_ut.generate_descriptors_soap(
-                    database=md_traj_short,
-                    descriptor_settings=settings['descriptors'],
+                descriptor_dict, descriptor_arr, uuids = (
+                    mdb_al_ut.generate_descriptors_soap(
+                        database=md_traj_short,
+                        descriptor_settings=settings['descriptors'],
+                    )
                 )
             else:
-                descriptor_dict, descriptor_arr, uuid = (
+                descriptor_dict, descriptor_arr, uuids = (
                     mdb_al_ut.generate_descriptors_mace(
                         model_path=prepend_path / 'sampler_model.model',
                         database=md_traj_short,

--- a/src/MatDBForge/core/command_line/cli_active_learning.py
+++ b/src/MatDBForge/core/command_line/cli_active_learning.py
@@ -743,11 +743,31 @@ def run_active_learning():
     # Create the subparser for the 'resume' command
     resume_parser = subparsers.add_parser(
         'resume',
-        help='Resume an active learning loop using a results folder.',
+        help=(
+            'Resume a MatDBForge Active Learning Loop. '
+            'The resume command allows to continue a stopped '
+            'active learning loop using its results folder. '
+            'The code will check for the files in the folder and '
+            'restart the last attempted iteration from the beginning. '
+            'The training database will be loaded from the results folder, '
+            'and the seed database can be loaded from the results folder '
+            'or reinitialized from the current training database.'
+            'The old_log_path option can be provided to continue the '
+            'logging from the previous run.'
+        ),
         usage=(
             'run_active_learning resume [-h] --dir_resume <PATH> '
             '[--config_file <PATH>]\n\n'
-            'Resume an active learning loop using a results folder.'
+            'Resume a MatDBForge Active Learning Loop.\n'
+            'The resume command allows to continue a stopped '
+            'active learning loop using its results folder.\n'
+            'The code will check for the files in the folder and\n'
+            'restart the last attempted iteration from the beginning.\n'
+            'The training database will be loaded from the results,\n'
+            'folder and the seed database can be loaded from the results\n'
+            'folder or reinitialized from the current training database.\n'
+            'The old_log_path option can be provided to continue the\n'
+            'logging from the previous run.'
         ),
     )
 


### PR DESCRIPTION
This pull request makes improvements to both the user interface and internal consistency of the active learning workflow in MatDBForge. The most significant updates include clarifying the help and usage messages for the 'resume' command in the CLI, and standardizing the output structure of descriptor generation functions to avoid scope bugs.

**Command-line interface improvements:**

* Enhanced the help and usage messages for the `resume` command in `run_active_learning`, providing detailed information about how the command works, what files are used, and how logging can be continued from a previous run.

**Internal consistency and code quality:**

* Standardized the return values of descriptor generation functions in `mdb_run_safeguard_md.py` so both SOAP and MACE descriptor generation now return `descriptor_dict`, `descriptor_arr`, and `uuids`, ensuring consistent variable names and output structure, and avoids overwriting the uuid module, which resulted in a crash when running the safeguard simulation.