### PR TITLE
Autoencoder train fixes

### DIFF
--- a/docs/source/input_active_learning.md
+++ b/docs/source/input_active_learning.md
@@ -439,12 +439,12 @@ This section is optional.
 - {alt}`target_alpha_range_max`:
   - **Description**: Maximum alpha value for the concave hull.
   - **Type**: `(optional, float)`
-  - **Default**: `50.0`.
+  - **Default**: `350.0`.
 
 - {alt}`default_alpha_if_issues`:
   - **Description**: Default alpha value if there are issues with the concave hull generation.
   - **Type**: `(optional, float)`
-  - **Default**: `5.0`.
+  - **Default**: `10.0`.
 
 - {alt}`nn_dist_scale_factor`:
   - **Description**: Scaling factor for the alpha candidate calculation, where `alpha_candidate = nn_dist_scale_factor / mean_nn_dist`

--- a/src/MatDBForge/active_learning/extrapolation/train_autoencoder.py
+++ b/src/MatDBForge/active_learning/extrapolation/train_autoencoder.py
@@ -366,7 +366,12 @@ def run_training(args):
     # )
 
     # Number of input dimensions
-    input_dim = dataset.shape[1]
+    if isinstance(train_data, DataLoader):
+        input_dim = train_data.dataset.dataset.tensors[0].shape[1]
+    elif isinstance(dataset, np.ndarray):
+        input_dim = dataset.shape[1]
+    else:
+        raise ValueError(f'Unexpected dataset type: {type(dataset)}')
 
     # Start a new wandb run to track this script
     if hasattr(args, 'wandb'):

--- a/src/MatDBForge/data/config_schema.yaml
+++ b/src/MatDBForge/data/config_schema.yaml
@@ -1106,12 +1106,12 @@ active_learning:
                 description: "Minimum alpha value for the concave hull."
             target_alpha_range_max:
                 type: float
-                default: 50.0
+                default: 350.0
                 mandatory: false
                 description: "Maximum alpha value for the concave hull."
             default_alpha_if_issues:
                 type: float
-                default: 5.0
+                default: 10.0
                 mandatory: false
                 description: "Default alpha value if there are issues with the concave hull generation."
             nn_dist_scale_factor:


### PR DESCRIPTION
This pull request fixes issues with autoencoder training data handling and updates the concave hull alpha parameter defaults for active learning:

**Error fixes:**

* Improved input dimension detection in `run_training` by handling both `DataLoader` and `np.ndarray` types, raising an error for unexpected types.

**Parameter default updates:**

* Increased the default value of `target_alpha_range_max` from 50.0 to 350.0 in both the configuration schema (`config_schema.yaml`) and the documentation (`input_active_learning.md`). [[1]](diffhunk://#diff-b581b957344e8920a9877addb394a04b23e7bdf1e984b0bc77d033c4bdeb4ebdL1109-R1114) [[2]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879L442-R447)
* Increased the default value of `default_alpha_if_issues` from 5.0 to 10.0 in both the configuration schema and the documentation. [[1]](diffhunk://#diff-b581b957344e8920a9877addb394a04b23e7bdf1e984b0bc77d033c4bdeb4ebdL1109-R1114) [[2]](diffhunk://#diff-3cd0361e0f0dd49391e9aea8c1227639dc775d899c258d242083a8e7b739d879L442-R447)

