### PR TITLE
fix: re-apply verified bug fixes on synced master

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-graft src/ATLAS/data
-include src/ATLAS/data/*
+graft src/atlas/data
+include src/atlas/data/*

--- a/src/atlas/active_learning/active_learning_utils.py
+++ b/src/atlas/active_learning/active_learning_utils.py
@@ -632,11 +632,13 @@ def select_structures_data_reduction(
     elif selection_method == 'fps':
         if descriptor_settings is None:
             raise ValueError('descriptor_settings required for fps selection method')
-        initial_structure_method = kwargs.get(
-            'initial_structure_method', 'lowest_energy'
-        )
         return select_structures_fps(
-            database, n_structures, descriptor_settings, initial_structure_method
+            candidate_db=database,
+            selected_db=[],
+            n_structures=n_structures,
+            descriptor_settings=descriptor_settings,
+            outer_average_mace=kwargs.get('outer_average_mace', False),
+            model_path=kwargs.get('model_path', None),
         )
     elif selection_method == 'uncertainty':
         if model_files is None:

--- a/src/atlas/active_learning/md/atl_process_structure.py
+++ b/src/atlas/active_learning/md/atl_process_structure.py
@@ -89,8 +89,10 @@ def check_traj_in_domain(
     # polygon formed by the concave hull.
     # If the concave hull has multiple parts, create a MultiPolygon
     # from all the parts.
-    if len(concave_hull) == 1:
+    if isinstance(concave_hull, list) and len(concave_hull) == 1:
         polygon = Polygon(concave_hull[0])
+    elif isinstance(concave_hull, np.ndarray) and concave_hull.ndim == 2:
+        polygon = Polygon(concave_hull)
     else:
         polygons = []
         for part in concave_hull:

--- a/src/atlas/core/code_utils.py
+++ b/src/atlas/core/code_utils.py
@@ -423,7 +423,7 @@ def init_config_dir(config_dir, config_file: str):
 def get_cache_path() -> pl.Path:
     """Get the path to ATLAS's the cacheuration directory."""
     # Try to get XDG_cache_HOME, if it doesn't exist, return None
-    cache_path = os.environ.get('$XDG_CACHE_HOME', None)
+    cache_path = os.environ.get('XDG_CACHE_HOME', None)
 
     # Check if $HOME/.cache exists and if it does, return the path
     if not cache_path:

--- a/src/atlas/core/database/diversity_metrics.py
+++ b/src/atlas/core/database/diversity_metrics.py
@@ -114,7 +114,7 @@ def get_vendi_score_db_rbf(
 
     custom_print(f'Feature matrix shape: {feature_matrix_X.shape}')
 
-    get_vendi_score(feature_matrix_X=feature_matrix_X, sigma=sigma, k=k)
+    return get_vendi_score(feature_matrix_X=feature_matrix_X, sigma=sigma, k=k)
 
 
 def get_vendi_score(

--- a/src/atlas/core/database/diversity_metrics.py
+++ b/src/atlas/core/database/diversity_metrics.py
@@ -318,7 +318,7 @@ def tanimoto_distance(struct_1_descriptors, struct_2_descriptors):
     Also known as Jaccard distance.
     """
     tanimoto = 1 - np.sum(struct_1_descriptors * struct_2_descriptors) / (
-        np.sum(np.max(struct_1_descriptors, struct_2_descriptors))
+        np.sum(np.maximum(struct_1_descriptors, struct_2_descriptors))
     )
     return tanimoto
 

--- a/src/atlas/core/database/diversity_metrics.py
+++ b/src/atlas/core/database/diversity_metrics.py
@@ -31,7 +31,7 @@ def get_feature_matrix_with_custom_features(dataset, feature_matrix_X):
     species_frac = np.zeros((len(dataset), len(species)))
     species_numbers = []
     for i, struct in enumerate(dataset):
-        species_frac[i] = [struct.symbols.count(s) / len(s) for s in species]
+        species_frac[i] = [struct.symbols.count(s) / len(struct) for s in species]
         species_numbers.append(
             [atomic_numbers[s] if struct.symbols.count(s) > 0 else 0 for s in species]
         )

--- a/src/atlas/core/filtering/structure_filters.py
+++ b/src/atlas/core/filtering/structure_filters.py
@@ -88,7 +88,9 @@ def apply_struct_filters_atl_db(structures, config_dict: dict):
             # print('structure: ', type(structures))
             structure = AseAtomsAdaptor().get_atoms(row[1].structure)
 
-            if structure.info.get('base') or structure.info.get('base'):
+            if getattr(row[1], 'base', False) or getattr(
+                row[1], 'isolated_atom', False
+            ):
                 continue
 
             struct_filter_results = []

--- a/src/atlas/core/utils.py
+++ b/src/atlas/core/utils.py
@@ -385,6 +385,8 @@ def apply_replacement_no_db(
     if not rng:
         rng = np.random.default_rng()
 
+    is_ase = False
+
     if isinstance(structure, ATL_STRUCT_TYPES):
         structure = structure.structure
 

--- a/src/atlas/workflows/datatypes/mlip.py
+++ b/src/atlas/workflows/datatypes/mlip.py
@@ -10,26 +10,23 @@ from aiida.orm import Data
 class MLIPModelFileData(Data):
     """A new data type that contains a MLIP model."""
 
+    def __init__(self, filepath, architecture, **kwargs):
+        """Construct a new instance and set the contents to that of the file.
 
-def __init__(self, filepath, architecture, **kwargs):
-    """Construct a new instance and set the contents to that of the file.
+        :param filepath: an absolute filepath of the file to wrap
+        :param architecture: the MLIP architecture (e.g. 'mace')
+        """
+        super().__init__(**kwargs)
 
-    :param file: an absolute filepath of the file to wrap
-    """
-    super().__init__(**kwargs)
+        # Get the filename from the absolute path
+        filename = os.path.basename(filepath)
 
-    # Remove unexpected value from keyword arguments
-    architecture = kwargs.pop('architecture')
+        # Store the file in the repository under the given filename
+        self.put_object_from_file(filepath, filename)
 
-    # Get the filename from the absolute path
-    filename = os.path.basename(filepath)
-
-    # Store the file in the repository under the given filename
-    self.put_object_from_file(filepath, filename)
-
-    # Store in the attributes what the filename is
-    self.base.attributes.set('filename', filename)
-    self.base.attributes.set('architecture', architecture)
+        # Store in the attributes what the filename is
+        self.base.attributes.set('filename', filename)
+        self.base.attributes.set('architecture', architecture)
 
     @property
     def architecture(self):
@@ -44,9 +41,11 @@ def __init__(self, filepath, architecture, **kwargs):
         model_data_bytes = self.get_object_content(filename, mode='rb')
 
         if curr_architecture.lower() in ['mace', 'scaleshiftmace', 'mace_ase', '']:
-            # Write the bytes to a temporary file and return the path
+            # Write the bytes to a temporary file and load it back
             with tempfile.NamedTemporaryFile(delete=True, suffix='.model') as temp_file:
                 temp_file.write(model_data_bytes)
+                temp_file.flush()
+                temp_file.seek(0)
                 model = torch.load(temp_file)
         else:
             raise NotImplementedError('Only MACE models are allowed for now.')

--- a/tests/test_code_utils.py
+++ b/tests/test_code_utils.py
@@ -113,15 +113,11 @@ class TestGetCachePath:
         path = get_cache_path()
         assert isinstance(path, pathlib.Path)
 
-    def test_uses_literal_dollar_prefix_bug(self, monkeypatch):
-        """Known bug: uses '$XDG_CACHE_HOME' instead of 'XDG_CACHE_HOME'.
-        This means the env var is never picked up. This test verifies the bug exists.
-        """
+    def test_uses_xdg_cache_home_env_var(self, monkeypatch):
+        """XDG_CACHE_HOME, when set, must be honored as the cache path."""
         monkeypatch.setenv('XDG_CACHE_HOME', '/custom/cache')
         path = get_cache_path()
-        # If the bug is present, the env var with the literal '$' is not found
-        # and it falls through to the home/.cache check
-        assert str(path) != '/custom/cache'
+        assert str(path) == '/custom/cache'
 
 
 class TestInitConfigDir:


### PR DESCRIPTION
## Summary

Re-applies the verified bug fixes from the earlier (discarded) bug-fix PR, rebased onto the current synced master. Each fix is its own commit. Two fixes from the original set were **dropped** because the synced upstream already resolved them.

### Applied (10 fixes)
| Fix | File |
|-----|------|
| MANIFEST.in casing (`src/ATLAS/data` → `src/atlas/data`) so `data/` ships | `MANIFEST.in` |
| `get_cache_path` honors `XDG_CACHE_HOME` (dropped literal `$`) + test | `core/code_utils.py`, `tests/test_code_utils.py` |
| `select_structures_fps` called with correct args (was shifted positionals) | `active_learning/active_learning_utils.py` |
| `MLIPModelFileData` methods defined inside the class | `workflows/datatypes/mlip.py` |
| species fraction `/ len(struct)` (was `/ len(symbol)`) | `core/database/diversity_metrics.py` |
| `get_vendi_score_db_rbf` returns its result | `core/database/diversity_metrics.py` |
| `np.maximum` in `tanimoto_distance` (was `np.max`) | `core/database/diversity_metrics.py` |
| `is_ase` initialized before use in `apply_replacement` | `core/utils.py` |
| concave-hull ndarray branch in `check_traj_in_domain` | `active_learning/md/atl_process_structure.py` |
| filter base-skip reads the dataframe row (was duplicate empty `.info` key) | `core/filtering/structure_filters.py` |

### Dropped (already fixed upstream on the synced master)
- `clusters.py` `is False` → upstream already uses `== False` in the refactored `apply_replacement_cluster_db`.
- `can_submit_calculation` tuple-as-bool → the buggy file `workflows/active_learning.py` was deleted upstream; remaining callers already unpack correctly.

## Test plan

- [x] `py_compile` clean on all changed files
- [x] `pytest tests/` → **157 passed, 0 failed** (4 errors are `test_structure_viewer.py` missing optional `PySide6`, unrelated)
- [x] `test_gen_db` (schema/`data/` packaging) and the `XDG_CACHE_HOME` test pass